### PR TITLE
add Transaction#GetCurrentStatus() for notifying users whether or not…

### DIFF
--- a/include/lineairdb/transaction.h
+++ b/include/lineairdb/transaction.h
@@ -16,6 +16,8 @@
 #ifndef LINEAIRDB_TRANSACTION_H
 #define LINEAIRDB_TRANSACTION_H
 
+#include <lineairdb/tx_status.h>
+
 #include <cstddef>
 #include <cstring>
 #include <memory>
@@ -46,6 +48,18 @@ namespace LineairDB {
  **/
 class Transaction {
  public:
+  /**
+   * @brief Get the current transaction status.
+   * For transactions such that GetCurrentStatus() returns TxStatus::Aborted,
+   * it is not guaranteed for subsequent read operations returns the correct
+   * values.
+   * @return TxStatus
+   */
+  TxStatus GetCurrentStatus();
+  bool IsRunning() { return GetCurrentStatus() == TxStatus::Running; }
+  bool IsCommitted() { return GetCurrentStatus() == TxStatus::Aborted; }
+  bool IsAborted() { return GetCurrentStatus() == TxStatus::Aborted; }
+
   /**
    * @brief If the database contains a data item for "key", returns a pair
    * (a pointer of value, the size of value).

--- a/include/lineairdb/tx_status.h
+++ b/include/lineairdb/tx_status.h
@@ -22,7 +22,7 @@ namespace LineairDB {
   @brief When a transaction terminates, database must return Committed or
   Aborted. The following enum describes them.
  */
-enum TxStatus { NotYetTerminated, Committed, Aborted };
+enum TxStatus { Running, Committed, Aborted };
 
 }  // namespace LineairDB
 

--- a/src/concurrency_control/concurrency_control_base.h
+++ b/src/concurrency_control/concurrency_control_base.h
@@ -31,6 +31,7 @@ struct TransactionReferences {
   ReadSetType& read_set_ref_;
   WriteSetType& write_set_ref_;
   const EpochNumber& my_epoch_ref_;
+  TxStatus& current_status_ref_;
 };
 class ConcurrencyControlBase {
  public:

--- a/src/transaction_impl.h
+++ b/src/transaction_impl.h
@@ -54,6 +54,7 @@ class Transaction::Impl {
   Impl(Database::Impl*) noexcept;
   ~Impl() noexcept;
 
+  TxStatus GetCurrentStatus();
   const std::pair<const std::byte* const, const size_t> Read(
       const std::string_view key);
   void Write(const std::string_view key, const std::byte value[],
@@ -62,7 +63,10 @@ class Transaction::Impl {
   bool Precommit();
 
  private:
-  bool user_aborted_;
+  bool IsAborted() { return current_status_ == TxStatus::Aborted; };
+
+ private:
+  TxStatus current_status_;
   Database::Impl* db_pimpl_;
   const Config& config_ref_;
   std::unique_ptr<ConcurrencyControlBase> concurrency_control_;


### PR DESCRIPTION
… transactions abort before commit request

So far, the return value of `Transaction::Read`, `std::pair<void *, size_t>`,  were undefined for transactions where the abort was determined by concurrency control protocols.
`GetCurrentStatus()` can notify users aborting before reading such undefined values to avoid causing bugs such as SEGV.