### PR TITLE
Fix gettid usage for earlier than glibc 2.30

### DIFF
--- a/src/thread_pool/thread_pool.cpp
+++ b/src/thread_pool/thread_pool.cpp
@@ -23,6 +23,11 @@
 #include <unistd.h>
 #endif
 
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define gettid() syscall(SYS_gettid)
+#endif
+
 #include <atomic>
 #include <functional>
 #include <mutex>

--- a/src/thread_pool/thread_pool.cpp
+++ b/src/thread_pool/thread_pool.cpp
@@ -21,11 +21,12 @@
 #ifndef __APPLE__
 #include <numa.h>
 #include <unistd.h>
-#endif
 
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
 #include <sys/syscall.h>
 #define gettid() syscall(SYS_gettid)
+#endif
+
 #endif
 
 #include <atomic>


### PR DESCRIPTION
The earlier version of glibc didn't support gettid()
wrapper and it causes  build error as undeclared function.
Unfortunately Ubuntu 18.04(bionic) which is a current major
OS destro, still uses 2.27. For more use cases, it should
be nice to have a macro to help syscall for gettid in
the thread_pool module with this patch.

Closes: https://github.com/LineairDB/LineairDB/issues/246

ref 1: https://man7.org/linux/man-pages/man2/gettid.2.html
ref 2: https://packages.ubuntu.com/ja/source/bionic/glibc