### PR TITLE
Add build flags for non-x86 architecture machines such as Apple M1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ### Compiler Options
 set(CMAKE_C_FLAGS "--std=c99")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -mcx16 -fPIC -march=native")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -mcx16 -fPIC")
+if (APPLE)
+  set(CMAKE_OSX_ARCHITECTURES "x86_64")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -g -O0 --save-temps -fno-omit-frame-pointer")
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ git clone --recurse-submodules https://github.com/lineairdb/lineairdb.git
 Quick start:
 
 ```
+brew install boost # for OSX
 mkdir -p build && cd build
 cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release .. && make && sudo make install
 ```
 
-Then you can use LineairDB by including the header `include/lineairdb/lineairdb.h`.
+Then you can use LineairDB by including the header `lineairdb/lineairdb.h`.
 
 ### Compatibility
 


### PR DESCRIPTION
closes #248.
I confirmed passing the build with AppleClang(arm64) on M1 Macbook.
In this patch, I forced the build target architecture to x86-64, but we should consider arm64 builds in the future.
However, unfortunately, the GitHub Actions runner of the M1 Mac does not seem to be available yet. (see https://github.com/actions/virtual-environments/issues/2187)