### PR TITLE
Add configurable working log directory option

### DIFF
--- a/include/lineairdb/config.h
+++ b/include/lineairdb/config.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <thread>
+#include <string>
 
 namespace LineairDB {
 

--- a/include/lineairdb/config.h
+++ b/include/lineairdb/config.h
@@ -149,6 +149,15 @@ struct Config {
    * Default: 30
    */
   size_t checkpoint_period = 30;
+  /**
+   * @brief
+   * The directory path that lineardb use as working directory.
+   * All of data, logs and related files are stored in the directory.
+   *
+   * Default: "lineairdb_logs"
+   */
+  // TODO: think of variable name, perhaps, sort of "work_dir" would be intuitive
+  std::string lineairdb_logs_dir = "./lineairdb_logs";
 };
 }  // namespace LineairDB
 

--- a/include/lineairdb/config.h
+++ b/include/lineairdb/config.h
@@ -157,8 +157,7 @@ struct Config {
    *
    * Default: "lineairdb_logs"
    */
-  // TODO: think of variable name, perhaps, sort of "work_dir" would be intuitive
-  std::string lineairdb_logs_dir = "./lineairdb_logs";
+  std::string work_dir = "./lineairdb_logs";
 };
 }  // namespace LineairDB
 

--- a/src/database_impl.h
+++ b/src/database_impl.h
@@ -221,7 +221,7 @@ class Database::Impl {
     SPDLOG_INFO("Start recovery process");
     // Start recovery from logfiles
     EpochNumber highest_epoch = 1;
-    const auto durable_epoch  = Recovery::Logger::GetDurableEpochFromLog();
+    const auto durable_epoch  = logger_.GetDurableEpochFromLog();
     SPDLOG_DEBUG("  Durable epoch is resumed from {0}", highest_epoch);
     logger_.SetDurableEpoch(durable_epoch);
     [[maybe_unused]] auto enqueued = thread_pool_.EnqueueForAllThreads(

--- a/src/database_impl.h
+++ b/src/database_impl.h
@@ -232,7 +232,7 @@ class Database::Impl {
 
     highest_epoch = std::max(highest_epoch, durable_epoch);
     auto&& recovery_set =
-        Recovery::Logger::GetRecoverySetFromLogs(durable_epoch);
+        logger_.GetRecoverySetFromLogs(durable_epoch);
     for (auto& entry : recovery_set) {
       highest_epoch = std::max(
           highest_epoch, entry.data_item_copy.transaction_id.load().epoch);

--- a/src/recovery/checkpoint_manager.hpp
+++ b/src/recovery/checkpoint_manager.hpp
@@ -49,8 +49,8 @@ class CPRManager {
 
   CPRManager(const LineairDB::Config& c_ref,
              LineairDB::Index::ConcurrentTable& t_ref, EpochFramework& e_ref)
-      : CheckpointFileName(c_ref.lineairdb_logs_dir + "/checkpoint.working.log"),
-	CheckpointWorkingFileName(c_ref.lineairdb_logs_dir + "/checkpoint.log"),
+      : CheckpointFileName(c_ref.lineairdb_logs_dir + "/checkpoint.log"),
+        CheckpointWorkingFileName(c_ref.lineairdb_logs_dir + "/checkpoint.working.log"),
         config_ref_(c_ref),
         table_ref_(t_ref),
         epoch_manager_ref_(e_ref),
@@ -149,6 +149,8 @@ class CPRManager {
                   std::ios_base::out | std::ios_base::binary);
               msgpack::pack(new_file, records);
               new_file.flush();
+              SPDLOG_DEBUG("RENAME checkpoint workingfile from {0} to {1}",
+                           CheckpointWorkingFileName, CheckpointFileName);
 
               // NOTE POSIX ensures that rename syscall provides atomicity
               if (rename(CheckpointWorkingFileName.c_str(), CheckpointFileName.c_str())) {

--- a/src/recovery/checkpoint_manager.hpp
+++ b/src/recovery/checkpoint_manager.hpp
@@ -44,13 +44,14 @@ namespace Recovery {
 class CPRManager {
  public:
   enum class Phase { REST, IN_PROGRESS, WAIT_FLUSH };
-  constexpr static auto CheckpointFileName = "lineairdb_logs/checkpoint.log";
-  constexpr static auto CheckpointWorkingFileName =
-      "lineairdb_logs/checkpoint.working.log";
+  const std::string CheckpointFileName;
+  const std::string CheckpointWorkingFileName;
 
   CPRManager(const LineairDB::Config& c_ref,
              LineairDB::Index::ConcurrentTable& t_ref, EpochFramework& e_ref)
-      : config_ref_(c_ref),
+      : CheckpointFileName(c_ref.lineairdb_logs_dir + "/checkpoint.working.log"),
+	CheckpointWorkingFileName(c_ref.lineairdb_logs_dir + "/checkpoint.log"),
+        config_ref_(c_ref),
         table_ref_(t_ref),
         epoch_manager_ref_(e_ref),
         current_phase_(Phase::REST),
@@ -150,7 +151,7 @@ class CPRManager {
               new_file.flush();
 
               // NOTE POSIX ensures that rename syscall provides atomicity
-              if (rename(CheckpointWorkingFileName, CheckpointFileName)) {
+              if (rename(CheckpointWorkingFileName.c_str(), CheckpointFileName.c_str())) {
                 SPDLOG_ERROR(
                     "Durability Error: fail to rename checkpoint of the "
                     "epoch "

--- a/src/recovery/checkpoint_manager.hpp
+++ b/src/recovery/checkpoint_manager.hpp
@@ -49,8 +49,8 @@ class CPRManager {
 
   CPRManager(const LineairDB::Config& c_ref,
              LineairDB::Index::ConcurrentTable& t_ref, EpochFramework& e_ref)
-      : CheckpointFileName(c_ref.lineairdb_logs_dir + "/checkpoint.log"),
-        CheckpointWorkingFileName(c_ref.lineairdb_logs_dir + "/checkpoint.working.log"),
+      : CheckpointFileName(c_ref.work_dir + "/checkpoint.log"),
+        CheckpointWorkingFileName(c_ref.work_dir + "/checkpoint.working.log"),
         config_ref_(c_ref),
         table_ref_(t_ref),
         epoch_manager_ref_(e_ref),

--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -80,8 +80,7 @@ void ThreadLocalLogger::Enqueue(const WriteSetType& ws_ref, EpochNumber epoch,
     // records and 2) will be terminated soon after here.
     // To ensure durability, we immediately flush the log records.
 
-    // TODO: to be good initiation if this file is not initialized via somehow
-    if (!my_storage->log_file) {
+    if (!my_storage->log_file.is_open()) {
       my_storage->log_file = std::fstream(
         GetLogFileName(my_storage->thread_id), std::fstream::out | std::fstream::binary | std::fstream::ate);
     }
@@ -96,7 +95,7 @@ void ThreadLocalLogger::FlushLogs(EpochNumber stable_epoch) {
   auto* my_storage = thread_key_storage_.Get();
 
   if (!my_storage->log_records.empty()) {
-    if (!my_storage->log_file) {
+    if (!my_storage->log_file.is_open()) {
       my_storage->log_file = std::fstream(
         GetLogFileName(my_storage->thread_id), std::fstream::out | std::fstream::binary | std::fstream::ate);
     }

--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -80,8 +80,8 @@ void ThreadLocalLogger::Enqueue(const WriteSetType& ws_ref, EpochNumber epoch,
     // The log record is not persisted when 1) this thread buffers its log
     // records and 2) will be terminated soon after here.
     // To ensure durability, we immediately flush the log records.
-    msgpack::pack(my_storage->log_file, my_storage->log_records);
-    my_storage->log_file.flush();
+    msgpack::pack(log_file, my_storage->log_records);
+    log_file.flush();
     my_storage->log_records.clear();
     my_storage->durable_epoch.store(epoch);
   }
@@ -91,8 +91,8 @@ void ThreadLocalLogger::FlushLogs(EpochNumber stable_epoch) {
   auto* my_storage = thread_key_storage_.Get();
 
   if (!my_storage->log_records.empty()) {
-    msgpack::pack(my_storage->log_file, my_storage->log_records);
-    my_storage->log_file.flush();
+    msgpack::pack(log_file, my_storage->log_records);
+    log_file.flush();
     my_storage->log_records.clear();
   }
 
@@ -159,7 +159,7 @@ void ThreadLocalLogger::TruncateLogs(
     exit(1);
   }
   my_storage->truncated_epoch = checkpoint_completed_epoch;
-  my_storage->log_file        = std::fstream(
+  log_file        = std::fstream(
       GetLogFileName(),
       std::fstream::out | std::fstream::binary | std::fstream::ate);
 }

--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -37,7 +37,7 @@ namespace LineairDB {
 namespace Recovery {
 
 ThreadLocalLogger::ThreadLocalLogger(const Config& config)
-  : config(config) {
+  : WorkingDir(config.lineairdb_logs_dir) {
     LineairDB::Util::SetUpSPDLog();
 }
 
@@ -186,11 +186,11 @@ EpochNumber ThreadLocalLogger::GetMinDurableEpochForAllThreads() {
 
 std::string ThreadLocalLogger::GetLogFileName(size_t thread_id) {
   // TODO: think of beautiful path concatation in C++
-  return config.lineairdb_logs_dir + "/thread" + std::to_string(thread_id) + ".log";
+  return WorkingDir + "/thread" + std::to_string(thread_id) + ".log";
 }
 
 std::string ThreadLocalLogger::GetWorkingLogFileName(size_t thread_id) {
-  return config.lineairdb_logs_dir + "/thread" + std::to_string(thread_id) +
+  return WorkingDir + "/thread" + std::to_string(thread_id) +
          ".working.log";
 }
 

--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -37,7 +37,7 @@ namespace LineairDB {
 namespace Recovery {
 
 ThreadLocalLogger::ThreadLocalLogger(const Config& config)
-  : WorkingDir(config.lineairdb_logs_dir) {
+  : WorkingDir(config.work_dir) {
     LineairDB::Util::SetUpSPDLog();
 }
 

--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -184,12 +184,12 @@ EpochNumber ThreadLocalLogger::GetMinDurableEpochForAllThreads() {
   return min_flushed_epoch;
 }
 
-std::string ThreadLocalLogger::GetLogFileName(size_t thread_id) {
+std::string ThreadLocalLogger::GetLogFileName(size_t thread_id) const {
   // TODO: think of beautiful path concatation in C++
   return WorkingDir + "/thread" + std::to_string(thread_id) + ".log";
 }
 
-std::string ThreadLocalLogger::GetWorkingLogFileName(size_t thread_id) {
+std::string ThreadLocalLogger::GetWorkingLogFileName(size_t thread_id) const {
   return WorkingDir + "/thread" + std::to_string(thread_id) +
          ".working.log";
 }

--- a/src/recovery/impl/thread_local_logger.h
+++ b/src/recovery/impl/thread_local_logger.h
@@ -66,8 +66,7 @@ class ThreadLocalLogger final : public LoggerBase {
     ThreadLocalStorageNode()
         : thread_id(ThreadIdCounter.fetch_add(1)),
           durable_epoch(EpochFramework::THREAD_OFFLINE),
-          truncated_epoch(0),
-          log_file(0){}
+          truncated_epoch(0) {}
     ~ThreadLocalStorageNode() {}
   };
 

--- a/src/recovery/impl/thread_local_logger.h
+++ b/src/recovery/impl/thread_local_logger.h
@@ -46,12 +46,11 @@ class ThreadLocalLogger final : public LoggerBase {
   void TruncateLogs(
       const EpochNumber checkpoint_completed_epoch) final override;
   EpochNumber GetMinDurableEpochForAllThreads() final override;
-  std::string GetLogFileName();
-  std::string GetWorkingLogFileName();
+  std::string GetLogFileName(size_t thread_id);
+  std::string GetWorkingLogFileName(size_t thread_id);
 
  private:
   const Config& config;
-  std::fstream log_file;
   struct ThreadLocalStorageNode {
    private:
     static std::atomic<size_t> ThreadIdCounter;
@@ -60,13 +59,15 @@ class ThreadLocalLogger final : public LoggerBase {
     size_t thread_id;
     std::atomic<EpochNumber> durable_epoch;
     EpochNumber truncated_epoch;
+    std::fstream log_file;
     Logger::LogRecords log_records;
     MSGPACK_DEFINE(log_records);
 
     ThreadLocalStorageNode()
         : thread_id(ThreadIdCounter.fetch_add(1)),
           durable_epoch(EpochFramework::THREAD_OFFLINE),
-          truncated_epoch(0) {}
+          truncated_epoch(0),
+          log_file(0){}
     ~ThreadLocalStorageNode() {}
   };
 

--- a/src/recovery/impl/thread_local_logger.h
+++ b/src/recovery/impl/thread_local_logger.h
@@ -60,7 +60,6 @@ class ThreadLocalLogger final : public LoggerBase {
     size_t thread_id;
     std::atomic<EpochNumber> durable_epoch;
     EpochNumber truncated_epoch;
-    std::fstream log_file;
     Logger::LogRecords log_records;
     MSGPACK_DEFINE(log_records);
 

--- a/src/recovery/impl/thread_local_logger.h
+++ b/src/recovery/impl/thread_local_logger.h
@@ -46,8 +46,8 @@ class ThreadLocalLogger final : public LoggerBase {
   void TruncateLogs(
       const EpochNumber checkpoint_completed_epoch) final override;
   EpochNumber GetMinDurableEpochForAllThreads() final override;
-  std::string GetLogFileName(size_t thread_id);
-  std::string GetWorkingLogFileName(size_t thread_id);
+  std::string GetLogFileName(size_t thread_id) const;
+  std::string GetWorkingLogFileName(size_t thread_id) const;
 
  private:
   std::string WorkingDir;

--- a/src/recovery/impl/thread_local_logger.h
+++ b/src/recovery/impl/thread_local_logger.h
@@ -50,7 +50,7 @@ class ThreadLocalLogger final : public LoggerBase {
   std::string GetWorkingLogFileName(size_t thread_id);
 
  private:
-  const Config& config;
+  std::string WorkingDir;
   struct ThreadLocalStorageNode {
    private:
     static std::atomic<size_t> ThreadIdCounter;

--- a/src/recovery/logger.cpp
+++ b/src/recovery/logger.cpp
@@ -46,10 +46,10 @@ Logger::Logger(const Config& config)
   LineairDB::Util::SetUpSPDLog();
   switch (config.logger) {
     case Config::Logger::ThreadLocalLogger:
-      logger_ = std::make_unique<ThreadLocalLogger>();
+      logger_ = std::make_unique<ThreadLocalLogger>(config);
       break;
     default:
-      logger_ = std::make_unique<ThreadLocalLogger>();
+      logger_ = std::make_unique<ThreadLocalLogger>(config);
       break;
   }
 }

--- a/src/recovery/logger.cpp
+++ b/src/recovery/logger.cpp
@@ -37,8 +37,8 @@ namespace LineairDB {
 namespace Recovery {
 
 Logger::Logger(const Config& config)
-    : DurableEpochNumberFileName(config.work_dir + "/durable_epoch_working.json"),
-      DurableEpochNumberWorkingFileName(config.work_dir + "/durable_epoch.json"),
+    : DurableEpochNumberFileName(config.work_dir + "/durable_epoch.json"),
+      DurableEpochNumberWorkingFileName(config.work_dir + "/durable_epoch.working.json"),
       WorkingDir(config.work_dir),
       durable_epoch_(0),
       durable_epoch_working_file_(DurableEpochNumberWorkingFileName, std::ofstream::trunc) {

--- a/src/recovery/logger.cpp
+++ b/src/recovery/logger.cpp
@@ -131,7 +131,7 @@ static inline std::vector<std::string> glob(const std::string& pat) {
 
 WriteSetType Logger::GetRecoverySetFromLogs(const EpochNumber durable_epoch) {
   SPDLOG_DEBUG("Replay the logs in epoch 0-{0}", durable_epoch);
-  SPDLOG_DEBUG("Check WrokingDirectory {0}", WorkingDir);
+  SPDLOG_DEBUG("Check WorkingDirectory {0}", WorkingDir);
 
   auto logfiles                      = glob(WorkingDir + "/thread*");
   const std::string checkpoint_filename = WorkingDir + "/checkpoint.log";

--- a/src/recovery/logger.cpp
+++ b/src/recovery/logger.cpp
@@ -37,13 +37,13 @@ namespace LineairDB {
 namespace Recovery {
 
 Logger::Logger(const Config& config)
-    : DurableEpochNumberFileName(config.lineairdb_logs_dir + "/durable_epoch_working.json"),
-      DurableEpochNumberWorkingFileName(config.lineairdb_logs_dir + "/durable_epoch.json"),
-      WorkingDir(config.lineairdb_logs_dir),
+    : DurableEpochNumberFileName(config.work_dir + "/durable_epoch_working.json"),
+      DurableEpochNumberWorkingFileName(config.work_dir + "/durable_epoch.json"),
+      WorkingDir(config.work_dir),
       durable_epoch_(0),
       durable_epoch_working_file_(DurableEpochNumberWorkingFileName, std::ofstream::trunc) {
 
-  std::experimental::filesystem::create_directory(config.lineairdb_logs_dir);
+  std::experimental::filesystem::create_directory(config.work_dir);
   LineairDB::Util::SetUpSPDLog();
   switch (config.logger) {
     case Config::Logger::ThreadLocalLogger:

--- a/src/recovery/logger.h
+++ b/src/recovery/logger.h
@@ -73,7 +73,7 @@ class Logger {
   std::unique_ptr<LoggerBase> logger_;
   EpochNumber durable_epoch_;
   std::ofstream durable_epoch_working_file_;
-  std::string lineairdb_logs_dir_;
+  std::string work_dir_;
 };
 
 }  // namespace Recovery

--- a/src/recovery/logger.h
+++ b/src/recovery/logger.h
@@ -32,10 +32,8 @@ namespace Recovery {
 class Logger {
  public:
   constexpr static EpochNumber NumberIsNotUpdated = 0;
-  constexpr static auto DurableEpochNumberFileName =
-      "lineairdb_logs/durable_epoch.json";
-  constexpr static auto DurableEpochNumberWorkingFileName =
-      "lineairdb_logs/durable_epoch_working.json";
+  const std::string DurableEpochNumberFileName;
+  const std::string DurableEpochNumberWorkingFileName;
 
   Logger(const Config&);
   ~Logger();
@@ -50,7 +48,7 @@ class Logger {
   EpochNumber FlushDurableEpoch();
   EpochNumber GetDurableEpoch();
   void SetDurableEpoch(const EpochNumber);
-  static EpochNumber GetDurableEpochFromLog();
+  EpochNumber GetDurableEpochFromLog();
   static WriteSetType GetRecoverySetFromLogs(const EpochNumber durable_epoch);
 
   struct LogRecord {
@@ -74,6 +72,7 @@ class Logger {
   std::unique_ptr<LoggerBase> logger_;
   EpochNumber durable_epoch_;
   std::ofstream durable_epoch_working_file_;
+  std::string lineairdb_logs_dir_;
 };
 
 }  // namespace Recovery

--- a/src/recovery/logger.h
+++ b/src/recovery/logger.h
@@ -34,6 +34,7 @@ class Logger {
   constexpr static EpochNumber NumberIsNotUpdated = 0;
   const std::string DurableEpochNumberFileName;
   const std::string DurableEpochNumberWorkingFileName;
+  const std::string WorkingDir;
 
   Logger(const Config&);
   ~Logger();
@@ -49,7 +50,7 @@ class Logger {
   EpochNumber GetDurableEpoch();
   void SetDurableEpoch(const EpochNumber);
   EpochNumber GetDurableEpochFromLog();
-  static WriteSetType GetRecoverySetFromLogs(const EpochNumber durable_epoch);
+  WriteSetType GetRecoverySetFromLogs(const EpochNumber durable_epoch);
 
   struct LogRecord {
     struct KeyValuePair {

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -47,6 +47,7 @@ TEST_F(DatabaseTest, InstantiateWithConfig) {
   db_.reset(nullptr);
   LineairDB::Config conf;
   conf.checkpoint_period = 1;
+  ASSERT_EQ("./lineairdb_logs", conf.lineairdb_logs_dir);
   ASSERT_NO_THROW(db_ = std::make_unique<LineairDB::Database>(conf));
 }
 

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -34,7 +34,7 @@ class DatabaseTest : public ::testing::Test {
   LineairDB::Config config_;
   std::unique_ptr<LineairDB::Database> db_;
   virtual void SetUp() {
-    std::experimental::filesystem::remove_all("lineairdb_logs");
+    std::experimental::filesystem::remove_all(config_.work_dir);
     config_.max_thread        = 4;
     config_.checkpoint_period = 1;
     config_.epoch_duration_ms = 1;
@@ -48,7 +48,6 @@ TEST_F(DatabaseTest, InstantiateWithConfig) {
   db_.reset(nullptr);
   LineairDB::Config conf;
   conf.checkpoint_period = 1;
-  ASSERT_EQ("./lineairdb_logs", conf.lineairdb_logs_dir);
   ASSERT_NO_THROW(db_ = std::make_unique<LineairDB::Database>(conf));
 }
 


### PR DESCRIPTION
In the current LinearDB master, the working directory is hardcoded to "lineairdb_logs" directory.
This implementation may block to create multi db instance from multi process because it will be
created under current working directory of the root process. 

To make LineairDB more usable, this pull request attempts to add an option to config the LineairDB working
directory that is like recent modern light weight databases (e.g. leveldb, sqlite).

## For reviewers
- This pull request is now ready for reviews
- Need feedbacks on following items
  - Variable names (e.g. lineardb_logs_dir on Config class) for new implementation
  - Coding rules to follow on
  - Ideas for tests because current test suits are tightened up to hardcoded value
  - C++ implementation best practices on whatever (e.g. around file system path handling)
