### PR TITLE
fix copy assignment operator of DataItem to copy cc_tag

### DIFF
--- a/src/types/data_item.hpp
+++ b/src/types/data_item.hpp
@@ -63,6 +63,7 @@ struct DataItem {
   }
   DataItem& operator=(const DataItem& rhs) {
     transaction_id.store(rhs.transaction_id.load());
+    cc_tag = rhs.cc_tag;
     buffer.Reset(rhs.buffer);
     return *this;
   }


### PR DESCRIPTION
closed: https://github.com/LineairDB/LineairDB/issues/267

The `cc_tag` member variable is not copied at the copy-assignment operator.