### PR TITLE
inserting operations are sometimes deferred to execute. fix some test…

### DIFF
--- a/src/database_impl.h
+++ b/src/database_impl.h
@@ -119,16 +119,19 @@ class Database::Impl {
     }
   }
 
-  Transaction& BeginTransaction() { return *(new Transaction(this)); }
+  Transaction& BeginTransaction() {
+    epoch_framework_.MakeMeOnline();
+    return *(new Transaction(this));
+  }
 
   bool EndTransaction(Transaction& tx, CallbackType clbk) {
     if (tx.IsAborted()) {
       clbk(TxStatus::Aborted);
       delete &tx;
+      epoch_framework_.MakeMeOffline();
       return false;
     }
 
-    epoch_framework_.MakeMeOnline();
     bool committed = tx.Precommit();
     if (committed) {
       tx.tx_pimpl_->PostProcessing(TxStatus::Committed);

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -131,7 +131,7 @@ TEST_F(DatabaseTest, ScanWithPhantomAvoidance) {
   // When there exists conflict between insertion and scanning,
   // either one will abort.
   auto hit             = 0;
-  const auto committed = TestHelper::DoTransactionsOnMultiThreads(
+  const auto committed = TestHelper::DoHandlerTransactionsOnMultiThreads(
       db_.get(),
       {[&](LineairDB::Transaction& tx) { tx.Write<int>("dave", dave); },
        [&](LineairDB::Transaction& tx) {

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -54,14 +54,24 @@ size_t DoTransactionsOnMultiThreads(
   std::atomic<size_t> terminated(0);
   std::atomic<size_t> committed(0);
   std::vector<std::future<void>> jobs;
+  std::atomic<size_t> waits(0);
+  std::atomic<bool> barrier(false);
   for (auto& tx : txns) {
     jobs.push_back(std::async(std::launch::async, [&]() {
+      waits.fetch_add(1);
+      for (;;) {
+        if (barrier.load()) break;
+      }
       db->ExecuteTransaction(tx, [&](const auto status) {
         terminated++;
         if (status == LineairDB::TxStatus::Committed) { committed++; }
       });
     }));
   }
+  for (;;) {
+    if (waits.load() == txns.size()) break;
+  }
+  barrier.store(true);
 
   for (auto& job : jobs) { job.wait(); }
 
@@ -81,9 +91,17 @@ size_t DoHandlerTransactionsOnMultiThreads(
     LineairDB::Database* db, const std::vector<TransactionProcedure> txns) {
   std::atomic<size_t> terminated(0);
   std::atomic<size_t> committed(0);
+
   std::vector<std::future<void>> jobs;
+  std::atomic<bool> barrier(false);
+  std::atomic<size_t> waits(0);
+
   for (auto& proc : txns) {
     jobs.push_back(std::async(std::launch::async, [&]() {
+      waits.fetch_add(1);
+      for (;;) {
+        if (barrier.load()) break;
+      }
       auto& tx = db->BeginTransaction();
       proc(tx);
       db->EndTransaction(tx, [&](auto status) {
@@ -94,6 +112,10 @@ size_t DoHandlerTransactionsOnMultiThreads(
       });
     }));
   }
+  for (;;) {
+    if (waits.load() == txns.size()) break;
+  }
+  barrier.store(true);
 
   for (auto& job : jobs) { job.wait(); }
 

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -129,7 +129,7 @@ size_t DoHandlerTransactionsOnMultiThreads(
   }
 
   return committed;
-}  // namespace TestHelper
+}
 
 }  // namespace TestHelper
 #endif /* LINEAIRDB_TEST_HELPER_HPP */


### PR DESCRIPTION
… cases.

### Background
In some index engine (e.g., epoch_based_range_index), inserting transactions might be deferred to execute.
In this case, subsequent scan operations might be aborted when their key ranges are conflicting with the insertions.

### What this PR solves
In the test case, there was an implicit assumption that __the index would always be reflected all insertion/deletions after `Sync` has triggered, and  the `Scan` operation would never fail just after the `Sync`.__ 
In this PR, I correct it to the actual implementation/specification.

### Future work
However, in practice, it would be useful to provide such property (`Sync` waits for the index to be stable/latest), we should modify it or prepare a new interface.

close https://github.com/LineairDB/LineairDB/issues/267