### PR TITLE
add options to Util::RetryWithExponentialBackoff

### DIFF
--- a/src/util/backoff.hpp
+++ b/src/util/backoff.hpp
@@ -24,13 +24,16 @@
 
 namespace LineairDB {
 namespace Util {
-static inline void RetryWithExponentialBackoff(std::function<bool()>&& f) {
+static inline bool RetryWithExponentialBackoff(std::function<bool()>&& f,
+                                               size_t sleep_ns         = 100,
+                                               size_t yield_threshold  = 100,
+                                               size_t retire_threshold = 0) {
   size_t try_count = 0;
-  size_t sleep_ns  = 100;
   for (;;) {
-    if (f()) return;
+    if (f()) return true;
     try_count++;
-    if (100 < try_count) {
+    if (0 < retire_threshold && retire_threshold < try_count) { return false; }
+    if (yield_threshold < try_count) {
       std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
       sleep_ns *= 2;
     } else {


### PR DESCRIPTION
### Background

`Util::RetryWithExponentialBackoff` retries a given function 100 times by using `std::this_thread::yield`, and after that, it shifts to do retrying infinite loop by using `std::this_thread::sleep_for(100ns)` until the function returns true.

### What this PR does

Remove magic numbers:

* add `sleep_ns` parameter.
* add `yield_threshold` parameter.

Add a parameter:

* `retire_threshold` to give up retrying the function.