### PR TITLE
Consolidate the config of Point Index and Range Index

### DIFF
--- a/bench/microbench/index/indexbench.cpp
+++ b/bench/microbench/index/indexbench.cpp
@@ -40,8 +40,7 @@ constexpr auto PopulationSize = 100000;
 template <typename T>
 void Population(T& index) {
   for (auto i = 0; i < PopulationSize; i++) {
-    const auto i_str  = std::to_string(i);
-    const auto result = index.GetOrInsert(i_str);
+    index.GetOrInsert(std::to_string(i));
   }
 }
 
@@ -191,7 +190,7 @@ int main(int argc, char** argv) {
     epoch_framework.Start();
     LineairDB::Config config;
     if (structure == "PrecisionLocking") {
-      config.range_index = decltype(config)::RangeIndex::PrecisionLockingIndex;
+      config.index_structure = decltype(config)::IndexStructure::HashTableWithPrecisionLockingIndex;
     } else {
       std::cout << "invalid structure name." << std::endl
                 << options.help() << std::endl;

--- a/include/lineairdb/config.h
+++ b/include/lineairdb/config.h
@@ -74,27 +74,16 @@ struct Config {
    */
   Logger logger = ThreadLocalLogger;
 
-  enum ConcurrentPointIndex { MPMCConcurrentHashSet };
+  enum IndexStructure { HashTableWithPrecisionLockingIndex };
   /**
    * @brief
-   * Set the type of concurrent point index.
-   * See LineairDB::Config::ConcurrentPointIndex for the enum options of this
+   * Set the type of index.
+   * See LineairDB::Config::IndexStructure for the enum options of this
    * configuration.
    *
-   * Default: MPMCConcurrentHashSet
+   * Default: Hash table with precision locking index
    */
-  ConcurrentPointIndex concurrent_point_index = MPMCConcurrentHashSet;
-
-  enum RangeIndex { PrecisionLockingIndex };
-  /**
-   * @brief
-   * Set the type of range index.
-   * See LineairDB::Config::RangeIndex for the enum options of this
-   * configuration.
-   *
-   * Default: ROWEX (epoch-based read-optimized write-exclusive index)
-   */
-  RangeIndex range_index = PrecisionLockingIndex;
+  IndexStructure index_structure = HashTableWithPrecisionLockingIndex;
 
   enum CallbackEngine { ThreadLocal };
   /**

--- a/src/index/concurrent_table.cpp
+++ b/src/index/concurrent_table.cpp
@@ -30,20 +30,22 @@ namespace Index {
 ConcurrentTable::ConcurrentTable(EpochFramework& epoch_framework, Config config,
                                  WriteSetType recovery_set)
     : epoch_manager_ref_(epoch_framework) {
-  switch (config.concurrent_point_index) {
-    case Config::ConcurrentPointIndex::MPMCConcurrentHashSet:
+  switch (config.index_structure) {
+    case Config::IndexStructure::HashTableWithPrecisionLockingIndex:
       point_index_ = std::make_unique<MPMCConcurrentSetImpl>();
       break;
     default:
       point_index_ = std::make_unique<MPMCConcurrentSetImpl>();
       break;
   }
-  switch (config.range_index) {
-    case Config::RangeIndex::PrecisionLockingIndex:
-      range_index_ = std::make_unique<PrecisionLockingIndex>(epoch_manager_ref_);
+  switch (config.index_structure) {
+    case Config::IndexStructure::HashTableWithPrecisionLockingIndex:
+      range_index_ =
+          std::make_unique<PrecisionLockingIndex>(epoch_manager_ref_);
       break;
     default:
-      range_index_ = std::make_unique<PrecisionLockingIndex>(epoch_manager_ref_);
+      range_index_ =
+          std::make_unique<PrecisionLockingIndex>(epoch_manager_ref_);
       break;
   }
   if (recovery_set.empty()) return;

--- a/tests/database_test.cpp
+++ b/tests/database_test.cpp
@@ -28,7 +28,6 @@
 #include "lineairdb/transaction.h"
 #include "lineairdb/tx_status.h"
 #include "test_helper.hpp"
-
 class DatabaseTest : public ::testing::Test {
  protected:
   LineairDB::Config config_;
@@ -99,7 +98,7 @@ TEST_F(DatabaseTest, Scan) {
        [&](LineairDB::Transaction& tx) {
          // Scan
          auto count = tx.Scan<decltype(alice)>(
-             "alice", "carol", [&](auto key, decltype(alice) value) {
+             "alice", "carol", [&](auto key, auto value) {
                if (key == "alice") { EXPECT_EQ(alice, value); }
                if (key == "bob") { EXPECT_EQ(bob, value); }
                if (key == "carol") { EXPECT_EQ(carol, value); }
@@ -110,7 +109,7 @@ TEST_F(DatabaseTest, Scan) {
        [&](LineairDB::Transaction& tx) {
          // Cancel
          auto count = tx.Scan<decltype(alice)>(
-             "alice", "carol", [&](auto key, decltype(alice) value) {
+             "alice", "carol", [&](auto key, auto value) {
                if (key == "alice") { EXPECT_EQ(alice, value); }
                return true;
              });


### PR DESCRIPTION
The approach of providing distinct options for each point indexes and range indexes has difficulties in dealing with the phantom problem.
LinearDB's `PrecisionLockingIndex` is one way to solve this problem, but I cannot imagine any other way to provide a separate indices.
For the sake of simplicity, this PR merge these config options `point_index` and `range_index` to `index_structure`.