### PR TITLE
remove Config.internal_buffer_size and use std::realloc instead

### DIFF
--- a/include/lineairdb/config.h
+++ b/include/lineairdb/config.h
@@ -148,14 +148,6 @@ struct Config {
    * Default: "lineairdb_logs"
    */
   std::string work_dir = "./lineairdb_logs";
-
-  /**
-   * @brief
-   * The size of the memory space allocated by LineairDB for each data item.
-   *
-   * Default: 512
-   */
-  size_t internal_buffer_size = 512;
 };
 }  // namespace LineairDB
 

--- a/src/database_impl.h
+++ b/src/database_impl.h
@@ -57,7 +57,6 @@ class Database::Impl {
           "the same time.");
       exit(1);
     }
-    DataBuffer::SetDefaultBufferSize(config_.internal_buffer_size);
     if (config_.enable_recovery) { Recovery(); }
     epoch_framework_.Start();
   }

--- a/src/types/data_buffer.hpp
+++ b/src/types/data_buffer.hpp
@@ -30,24 +30,24 @@
 namespace LineairDB {
 
 struct DataBuffer {
-  constexpr static size_t DefaultBufferSize = 512;
-
   std::byte* value;
   size_t size;
 
-  DataBuffer() : size(DefaultBufferSize) {
-    value = new std::byte[DefaultBufferSize];
-  }
+  DataBuffer() : size(0) { value = nullptr; }
   ~DataBuffer() {
     if (value != nullptr) delete[] value;
   }
 
   void Reset(const std::byte* v, const size_t s) {
     if (size < s) {
-      size  = s;
-      value = static_cast<decltype(value)>(
-          std::realloc(reinterpret_cast<void*>(value), s));
-      if (value == nullptr) { throw std::bad_alloc(); }
+      size = s;
+      if (value == nullptr) {
+        value = new std::byte[s];
+      } else {
+        value = static_cast<decltype(value)>(
+            std::realloc(reinterpret_cast<void*>(value), s));
+        if (value == nullptr) { throw std::bad_alloc(); }
+      }
     }
     std::memcpy(value, v, s);
   }

--- a/src/types/data_buffer.hpp
+++ b/src/types/data_buffer.hpp
@@ -39,8 +39,12 @@ struct DataBuffer {
   }
 
   void Reset(const std::byte* v, const size_t s) {
+    if (v == nullptr){
+      delete[] value;
+      value = nullptr;
+      size = 0;
+    }
     if (size < s) {
-      size = s;
       if (value == nullptr) {
         value = new std::byte[s];
       } else {
@@ -49,6 +53,7 @@ struct DataBuffer {
         if (value == nullptr) { throw std::bad_alloc(); }
       }
     }
+    size = s;
     std::memcpy(value, v, s);
   }
   void Reset(const DataBuffer& rhs) { Reset(rhs.value, rhs.size); }

--- a/tests/durability_test.cpp
+++ b/tests/durability_test.cpp
@@ -79,11 +79,6 @@ TEST_F(DurabilityTest, Recovery) {
 }
 
 TEST_F(DurabilityTest, RecoveryLargeObject) {
-  auto default_config                 = db_->GetConfig();
-  default_config.internal_buffer_size = 4096;
-  db_.reset(nullptr);
-  db_ = std::make_unique<LineairDB::Database>(default_config);
-
   std::string initial_value(4096, 'a');
   TestHelper::DoTransactions(
       db_.get(), {[&](LineairDB::Transaction& tx) {
@@ -93,9 +88,6 @@ TEST_F(DurabilityTest, RecoveryLargeObject) {
   db_->Fence();
 
   for (size_t i = 0; i < 3; i++) {
-    db_.reset(nullptr);
-    db_ = std::make_unique<LineairDB::Database>(default_config);
-
     TestHelper::DoTransactions(db_.get(), {[&](LineairDB::Transaction& tx) {
                                  auto alice = tx.Read("alice");
                                  ASSERT_TRUE(alice.first != nullptr);

--- a/tests/test_helper.hpp
+++ b/tests/test_helper.hpp
@@ -49,13 +49,6 @@ void RetryTransactionUntilCommit(LineairDB::Database* db,
   db->Fence();
 }
 
-template <typename T>
-void writeBufferAsAlice(LineairDB::Database* db, T desired) {
-  auto& tx = db->BeginTransaction();
-  tx.Write("alice", reinterpret_cast<std::byte*>(&desired), sizeof(desired));
-  db->EndTransaction(tx, [&](auto) {});
-}
-
 bool DoTransactions(LineairDB::Database* db,
                     const std::vector<TransactionProcedure> txns) {
   std::atomic<size_t> terminated(0);


### PR DESCRIPTION
fix #397.
We do not have to use `DefaultBufferSize` to set the internal buffer size.
Instead, this PR uses std::realloc to determine the buffer size dynamically.