### PR TITLE
Update ccpp.yml

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-10.15]
-        compiler: [g++-7, g++-9, clang++]
+        compiler: [g++-9, clang++]
         build: [Debug, Release]
 
     runs-on: ${{ matrix.os }}
@@ -26,10 +26,9 @@ jobs:
         run: brew install boost
       - name: install dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt update && sudo apt install -yq libboost-dev g++-7 libnuma-dev
+        run: sudo apt update && sudo apt install -yq libboost-dev libnuma-dev
       - name: checkout submodules
         shell: bash
-        if: matrix.os != 'macos-10.15' || matrix.compiler != 'g++-7'
         run: |
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
@@ -39,7 +38,6 @@ jobs:
         env:
           CXX: ${{ matrix.compiler }}
           BUILDTYPE: ${{ matrix.build }}
-        if: matrix.os != 'macos-10.15' || matrix.compiler != 'g++-7'
         run: |
           mkdir -p build; cd $_
           cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE)
@@ -54,7 +52,6 @@ jobs:
           echo '/cores/core.%h.%e.%t' | sudo tee -a /proc/sys/kernel/core_pattern
 
       - name: ${{ matrix.build }} test
-        if: matrix.os != 'macos-10.15' || matrix.compiler != 'g++-7'
         run: |
           cd build
           ctest -V
@@ -63,7 +60,6 @@ jobs:
         env:
           CXX: ${{ matrix.compiler }}
           BUILDTYPE: ${{ matrix.build }}
-        if: matrix.os != 'macos-10.15' || matrix.compiler != 'g++-7'
         run: |
           mkdir -p example/build; cd $_
           cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE)


### PR DESCRIPTION
This commit removes `gcc-7` from the testing matrix, since the version is unsupported by both `ubuntu-latest` and `macos-10.15`.