### PR TITLE
Mutual exclusion of #ForEach and Rehash in point index

### DIFF
--- a/tests/unit-tests/concurrent_table_test.cpp
+++ b/tests/unit-tests/concurrent_table_test.cpp
@@ -146,3 +146,37 @@ TEST(ConcurrentTableTest, TremendousGetAndPut) {
   }
   for (auto& thread : threads) { thread.join(); }
 }
+
+TEST(ConcurrentTableTest, ForEachIsSafeWithRehashing) {
+  // Test scenario: #Rehash and #ForEach are concurrently executed.
+  std::vector<std::thread> threads;
+  std::vector<LineairDB::DataItem*> items;
+  LineairDB::EpochFramework epoch(1);
+  LineairDB::Config config;
+  config.rehash_threshold = 0.3;
+  epoch.Start();
+  LineairDB::Index::ConcurrentTable table(epoch);
+
+  constexpr size_t working_set_size = 8192;
+  for (size_t i = 0; i < 5; i++) {
+    threads.emplace_back([&, i]() {
+      for (size_t j = i * working_set_size; j < (i + 1) * working_set_size;
+           j++) {
+        table.Put(std::to_string(j), {});
+      }
+    });
+  }
+  for (size_t i = 0; i < 5; i++) {
+    threads.emplace_back([&, i]() {
+      for (size_t j = 0; j < 100; j++) {
+        table.ForEach([](auto, auto) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          return true;
+        });
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}

--- a/tests/unit-tests/concurrent_table_test.cpp
+++ b/tests/unit-tests/concurrent_table_test.cpp
@@ -167,10 +167,10 @@ TEST(ConcurrentTableTest, ForEachIsSafeWithRehashing) {
     });
   }
   for (size_t i = 0; i < 5; i++) {
-    threads.emplace_back([&, i]() {
-      for (size_t j = 0; j < 100; j++) {
+    threads.emplace_back([&]() {
+      for (size_t j = 0; j < 3; j++) {
         table.ForEach([](auto, auto) {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          std::this_thread::sleep_for(std::chrono::microseconds(1));
           return true;
         });
       }


### PR DESCRIPTION
There is a concurrency bug that occurs when checkpointing and rehash run at the same time.
#ForEach should be exclusive with Rehash as its interface specification.

When checkpointing, all the records are retrieved from the primary index using #ForEach of MPMC Hashtable; however, if rehash is executed simultaneously, #ForEach has to jump to a new index, and it is impossible. Since the hash function (and the order of records) at the new index has changed, #ForEach cannot continue retrieving all records "from the next record”. In the worst case, it causes SEGV.


