### PR TITLE
Eliminate VLAs to build with Clang

### DIFF
--- a/bench/microbench/recoverytime/recovery_time_bench.cpp
+++ b/bench/microbench/recoverytime/recovery_time_bench.cpp
@@ -46,7 +46,7 @@ size_t benchmark(const size_t db_size, const size_t buffer_size,
     std::vector<std::future<void>> futures;
     const size_t thread_size            = std::thread::hardware_concurrency();
     const size_t per_worker_insert_size = db_size / thread_size;
-    std::byte buffer[buffer_size];
+    std::vector<std::byte> buffer(buffer_size);
 
     for (size_t i = 0; i < thread_size; i++) {
       futures.push_back(std::async(std::launch::async, [&, i]() {
@@ -56,7 +56,7 @@ size_t benchmark(const size_t db_size, const size_t buffer_size,
                 const size_t from = i * per_worker_insert_size;
                 const size_t to   = (i + 1) * per_worker_insert_size - 1;
                 for (size_t j = from; j < to; j++) {
-                  tx.Write(std::to_string(j), buffer, buffer_size);
+                  tx.Write(std::to_string(j), buffer.data(), buffer.size());
                 }
               },
               []([[maybe_unused]] LineairDB::TxStatus result) {

--- a/bench/ycsb/benchmark.cpp
+++ b/bench/ycsb/benchmark.cpp
@@ -73,9 +73,9 @@ void PopulateDatabase(LineairDB::Database& db, Workload& workload,
     workers.emplace_back([&, from, to]() {
       db.ExecuteTransaction(
           [&, from, to](LineairDB::Transaction& tx) {
-            std::byte ptr[workload.payload_size];
+            std::vector<std::byte> value(workload.payload_size);
             for (size_t idx = from; idx < to; idx++) {
-              tx.Write(std::to_string(idx), ptr, workload.payload_size);
+              tx.Write(std::to_string(idx), value.data(), value.size());
             }
           },
           [](LineairDB::TxStatus status) {


### PR DESCRIPTION
The build process fails due to the use of VLAs, despite claiming compatibility with Clang on Linux:

```
$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON
...
$ make -C build
[ 81%] Building CXX object bench/CMakeFiles/ycsb.dir/ycsb/benchmark.cpp.o
/home/sira/workspace/LineairDB/bench/microbench/recoverytime/recovery_time_bench.cpp:49:22: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
   49 |     std::byte buffer[buffer_size];
      |                      ^~~~~~~~~~~
[ 93%] Building CXX object bench/CMakeFiles/recoverytime.dir/microbench/recoverytime/recovery_time_bench.cpp.o
/home/sira/workspace/LineairDB/bench/ycsb/benchmark.cpp:76:27: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
   76 |             std::byte ptr[workload.payload_size];
      |                           ^~~~~~~~~~~~~~~~~~~~~
```