### PR TITLE
Fix: CMake optimization flags unintentionally overwritten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_C_FLAGS "--std=c99")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fPIC")
 if (NOT APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
 endif()
@@ -67,9 +67,9 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_DEBUG} -Ofast")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -Ofast -ffast-math -DNDEBUG")
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
   # Apple Sillicon (m1) does not support `march=native`. use `mcpu` instead.
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -mcpu=apple-m1")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mcpu=apple-m1")
 else()
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -march=native")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
 endif()
 
 # Build as library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_DEBUG} -Ofast")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -Ofast -ffast-math -DNDEBUG")
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-  # Apple Sillicon (m1) does not support `march=native`. use `mcpu` instead.
+  # Apple Silicon (m1) does not support `march=native`. use `mcpu` instead.
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mcpu=apple-m1")
 else()
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_C_FLAGS "--std=c99")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -fPIC")
 if (NOT APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcx16")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
   endif()
 endif()
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_DEBUG} -Ofast")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -Ofast -ffast-math -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3 -ffast-math -DNDEBUG")
 if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
   # Apple Silicon (m1) does not support `march=native`. use `mcpu` instead.
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mcpu=apple-m1")
@@ -100,12 +100,17 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   target_link_libraries(${PROJECT_NAME} pthread)
-else()
-  if(APPLE) # Use libc++
-    target_link_libraries(${PROJECT_NAME} c++ stdc++fs atomic pthread)
-  else() # Use libstdc++
-    target_link_libraries(${PROJECT_NAME} stdc++ stdc++fs atomic pthread numa)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(APPLE)
+    target_link_libraries(${PROJECT_NAME} pthread)
+  else()
+    target_link_libraries(${PROJECT_NAME} stdc++ atomic pthread numa)
   endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_link_libraries(${PROJECT_NAME} stdc++ atomic pthread numa)
+else()
+  message(WARNING "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}")
+  target_link_libraries(${PROJECT_NAME} pthread)
 endif()
 
 target_include_directories(
@@ -149,6 +154,10 @@ if(IS_TOPLEVEL_PROJECT AND BUILD_TESTS)
     add_subdirectory(third_party/googletest)
   endif()
   add_subdirectory(tests)
+  if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    # Suppress warnings about NaN and Infinity in gtest
+    set_target_properties(gtest PROPERTIES COMPILE_OPTIONS "-Wno-nan-infinity-disabled")
+  endif()
 endif()
 
 # Benchmarks

--- a/src/types/data_buffer.hpp
+++ b/src/types/data_buffer.hpp
@@ -43,17 +43,11 @@ struct DataBuffer {
       delete[] value;
       value = nullptr;
       size = 0;
+      return;
     }
     if (size < s) {
-      if (value == nullptr) {
-        value = new std::byte[s];
-      } else {
-        value = static_cast<decltype(value)>(
-            std::realloc(reinterpret_cast<void*>(value), s));
-        if (value == nullptr) {
-          throw std::bad_alloc();
-        }
-      }
+      delete[] value;
+      value = new std::byte[s];
     }
     size = s;
     std::memcpy(value, v, s);

--- a/src/types/data_buffer.hpp
+++ b/src/types/data_buffer.hpp
@@ -25,8 +25,6 @@
 #include <iostream>
 #include <new>
 
-#include "util/logger.hpp"
-
 namespace LineairDB {
 
 struct DataBuffer {


### PR DESCRIPTION
## Description of the changes

This PR fixes an issue in `CMakeLists.txt` where compiler optimization flags are unintentionally overwritten.

### Problem

There is an issue in `CMakeLists.txt` where `CMAKE_CXX_FLAGS_RELEASE` is overwritten instead of appended to, causing all optimization flags to be lost.

Lines 67-73 in CMakeLists.txt:
```cmake
set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -Ofast -ffast-math -DNDEBUG")
if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
  # Apple Sillicon (m1) does not support `march=native`. use `mcpu` instead.
  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -mcpu=apple-m1")
else()
  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -march=native")
endif()
```

In the conditional statements, `CMAKE_CXX_FLAGS_RELEASE` gets overwritten, losing all the optimization flags (`-Ofast -ffast-math -DNDEBUG`) that were set earlier.

### Changes Made

1. **Fixed flag overwriting**: Changed `${CMAKE_CXX_FLAGS}` to `${CMAKE_CXX_FLAGS_RELEASE}` to properly append architecture-specific flags
2. **Removed `-Werror`**: Removed to address compilation warnings that appear with proper optimization flags enabled

## Performance Impact

This fix provides a ~4x performance improvement in YCSB benchmarks:

**Before fix (flags overwritten):**
```bash
noxy@XG6326-2U:~/LineairDB/build/bench$ ./ycsb --thread 30 --clients 30 --records 100000 --contention 0.9 --epoch 1000
[Thread 276997] [2025-08-03 22:52:29.596] [info] [database_impl.h:53] LineairDB instance has been constructed. [+0msec]
[Thread 276997] [2025-08-03 22:52:29.599] [info] [benchmark.cpp:89] YCSB: Database population queries are enqueued [+3msec]
[Thread 276997] [2025-08-03 22:52:31.596] [info] [benchmark.cpp:94] YCSB: Database population is completed [+1996msec]
[Thread 276997] [2025-08-03 22:52:31.603] [info] [benchmark.cpp:235] YCSB: Benchmark start. [+6msec]
[Thread 276997] [2025-08-03 22:52:33.605] [info] [benchmark.cpp:245] YCSB: Benchmark end. [+2001msec]
[Thread 276997] [2025-08-03 22:52:38.598] [info] [benchmark.cpp:247] YCSB: DB Fenced. [+4993msec]
[Thread 276997] [2025-08-03 22:52:38.598] [info] [benchmark.cpp:261] YCSB: Benchmark completed. elapsed time: 2001ms, commits: 1050355, aborts: 469475, tps: 524915 [+0msec]
This benchmark result is saved into ycsb_result.json
[Thread 276997] [2025-08-03 22:52:44.598] [debug] [database_impl.h:76] Epoch number and Durable epoch number are ended at 16, and 0, respectively. [+6000msec]
[Thread 276997] [2025-08-03 22:52:44.598] [info] [database_impl.h:80] LineairDB instance has been destructed. [+0msec]
```

**After fix (proper optimization flags):**
```bash
noxy@XG6326-2U:~/LineairDB/build/bench$ ./ycsb --thread 30 --clients 30 --records 100000 --contention 0.9 --epoch 1000
[Thread 281862] [2025-08-03 22:59:11.050] [info] [database_impl.h:53] LineairDB instance has been constructed. [+0msec]
[Thread 281862] [2025-08-03 22:59:11.054] [info] [benchmark.cpp:89] YCSB: Database population queries are enqueued [+3msec]
[Thread 281862] [2025-08-03 22:59:13.051] [info] [benchmark.cpp:94] YCSB: Database population is completed [+1996msec]
[Thread 281862] [2025-08-03 22:59:13.059] [info] [benchmark.cpp:235] YCSB: Benchmark start. [+7msec]
[Thread 281862] [2025-08-03 22:59:15.060] [info] [benchmark.cpp:245] YCSB: Benchmark end. [+2001msec]
[Thread 281862] [2025-08-03 22:59:18.052] [info] [benchmark.cpp:247] YCSB: DB Fenced. [+2992msec]
[Thread 281862] [2025-08-03 22:59:18.052] [info] [benchmark.cpp:261] YCSB: Benchmark completed. elapsed time: 2001ms, commits: 4032400, aborts: 353478, tps: 2015192 [+0msec]
This benchmark result is saved into ycsb_result.json
[Thread 281862] [2025-08-03 22:59:24.052] [info] [database_impl.h:80] LineairDB instance has been destructed. [+6000msec]
```

## Discussion

With optimization flags properly enabled, the compiler generates warnings about memory allocation mismatches in `data_buffer.hpp` (mixing `new[]`/`delete[]` with `realloc`). This PR disables escalation of these warnings to errors by removing `-Werror`.

```bash
In file included from /home/noxy/LineairDB/src/types/data_item.hpp:30,
                 from /home/noxy/LineairDB/src/recovery/logger_base.h:20,
                 from /home/noxy/LineairDB/src/recovery/logger.h:25,
                 from /home/noxy/LineairDB/src/recovery/logger.cpp:17:
In member function ‘void LineairDB::DataBuffer::Reset(const std::byte*, size_t)’,
    inlined from ‘void LineairDB::DataBuffer::Reset(const std::string&)’ at /home/noxy/LineairDB/src/types/data_buffer.hpp:63:10,
    inlined from ‘LineairDB::WriteSetType LineairDB::Recovery::Logger::GetRecoverySetFromLogs(LineairDB::EpochNumber)’ at /home/noxy/LineairDB/src/recovery/logger.cpp:195:51:
/home/noxy/LineairDB/src/types/data_buffer.hpp:43:16: error: ‘void operator delete [](void*)’ called on a pointer passed to mismatched reallocation function ‘void* realloc(void*, size_t)’ [-Werror=mismatched-dealloc]
   43 |       delete[] value;
      |                ^~~~~
/home/noxy/LineairDB/src/types/data_buffer.hpp:52:25: note: call to ‘void* realloc(void*, size_t)’
   52 |             std::realloc(reinterpret_cast<void*>(value), s));
      |             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/noxy/LineairDB/src/types/data_buffer.hpp:43:16: error: ‘void operator delete [](void*)’ called on a pointer passed to mismatched reallocation function ‘void* realloc(void*, size_t)’ [-Werror=mismatched-dealloc]
   43 |       delete[] value;
      |                ^~~~~
/home/noxy/LineairDB/src/types/data_buffer.hpp:52:25: note: call to ‘void* realloc(void*, size_t)’
   52 |             std::realloc(reinterpret_cast<void*>(value), s));
      |             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

There are two potential approaches:

1. **Current approach**: Remove `-Werror` and accept the warnings as non-critical
2. **Alternative approach**: Keep `-Werror` and fix the memory allocation issue in `data_buffer.hpp` (and also somewhere else, maybe)