### PR TITLE
Fix accessing of uninitialized / already free'd member in destructor …

### DIFF
--- a/src/index/precision_locking_index/point_index/mpmc_concurrent_set_impl.hpp
+++ b/src/index/precision_locking_index/point_index/mpmc_concurrent_set_impl.hpp
@@ -130,16 +130,15 @@ class MPMCConcurrentSetImpl {
   const double rehash_threshold_;
   std::atomic<TableType*> table_;
   std::atomic<size_t> populated_count_;
+  EpochFramework epoch_framework_;
 
   std::mutex table_lock_;
   std::atomic<bool> stop_flag_{false};
 
   std::mutex rehash_flag_;
   std::condition_variable rehash_cv_;
-  std::thread rehash_thread_;
   std::atomic<bool> force_rehash_flag_{false};
-
-  EpochFramework epoch_framework_;
+  std::thread rehash_thread_;
 };
 
 /** the followings are implementation **/


### PR DESCRIPTION
…of MPMCConcurrentSet

The order in which the `epoch_framework` is constructed last and destructed first is incorrect.
Furthermore, there was also an incorrect order regarding `force_rehash_flag_`.

# Valgrind Result
```
> valgrind ./lineairdb-example 
==617099== Memcheck, a memory error detector
==617099== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==617099== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==617099== Command: ./lineairdb-example
==617099== 
==617099== Thread 23:
==617099== Conditional jump or move depends on uninitialised value(s)
==617099==    at 0x137B98: LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const (mpmc_concurrent_set_impl.hpp:95)
==617099==    by 0x1490E8: void std::condition_variable::wait<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const::{lambda()#1}>(std::unique_lock<std::mutex>&, LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const::{lambda()#1}) (condition_variable:102)
==617099==    by 0x1378D6: LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const (mpmc_concurrent_set_impl.hpp:91)
==617099==    by 0x19B6A6: void std::__invoke_impl<void, LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}>(std::__invoke_other, LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}&&) (invoke.h:61)
==617099==    by 0x19B2A1: std::__invoke_result<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}>::type std::__invoke<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}>(LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}&&) (invoke.h:96)
==617099==    by 0x19AD91: void std::thread::_Invoker<std::tuple<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (std_thread.h:259)
==617099==    by 0x19A4E1: std::thread::_Invoker<std::tuple<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}> >::operator()() (std_thread.h:266)
==617099==    by 0x1950B9: std::thread::_State_impl<std::thread::_Invoker<std::tuple<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::Table>::MPMCConcurrentSetImpl(double)::{lambda()#1}> > >::_M_run() (std_thread.h:211)
==617099==    by 0x4946252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
==617099==    by 0x4C4AAC2: start_thread (pthread_create.c:442)
==617099==    by 0x4CDBA03: clone (clone.S:100)
==617099== 
[Thread 617099] [2025-09-02 23:20:06.221] [info] [database_impl.h:54] LineairDB instance has been constructed. [+149msec]
==617099== Thread 26:
==617099== Conditional jump or move depends on uninitialised value(s)
==617099==    at 0x19E4BA: LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const (mpmc_concurrent_set_impl.hpp:95)
==617099==    by 0x19EC5A: void std::condition_variable::wait<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const::{lambda()#1}>(std::unique_lock<std::mutex>&, LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const::{lambda()#1}) (condition_variable:102)
==617099==    by 0x19E1F8: LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}::operator()() const (mpmc_concurrent_set_impl.hpp:91)
==617099==    by 0x19FD99: void std::__invoke_impl<void, LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}>(std::__invoke_other, LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}&&) (invoke.h:61)
==617099==    by 0x19FD54: std::__invoke_result<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}>::type std::__invoke<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}>(LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}&&) (invoke.h:96)
==617099==    by 0x19FCF5: void std::thread::_Invoker<std::tuple<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (std_thread.h:259)
==617099==    by 0x19FCC5: std::thread::_Invoker<std::tuple<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}> >::operator()() (std_thread.h:266)
==617099==    by 0x19FCA5: std::thread::_State_impl<std::thread::_Invoker<std::tuple<LineairDB::Index::MPMCConcurrentSetImpl<LineairDB::DataItem>::MPMCConcurrentSetImpl(double)::{lambda()#1}> > >::_M_run() (std_thread.h:211)
==617099==    by 0x4946252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
==617099==    by 0x4C4AAC2: start_thread (pthread_create.c:442)
==617099==    by 0x4CDBA03: clone (clone.S:100)
==617099== 
[Thread 617099] [2025-09-02 23:20:06.379] [info] [database_impl.h:263] Start recovery process [+157msec]
...
==617099== 
==617099== HEAP SUMMARY:
==617099==     in use at exit: 0 bytes in 0 blocks
==617099==   total heap usage: 2,267 allocs, 2,267 frees, 6,998,744 bytes allocated
==617099== 
==617099== All heap blocks were freed -- no leaks are possible
==617099== 
==617099== Use --track-origins=yes to see where uninitialised values come from
==617099== For lists of detected and suppressed errors, rerun with: -s
==617099== ERROR SUMMARY: 6 errors from 2 contexts (suppressed: 0 from 0)
```