### PR TITLE
ci: Add ASAN and TSAN build jobs to the test matrix; fix core concurrency data races

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         compiler: [g++, clang++]
@@ -68,6 +68,9 @@ jobs:
       - name: ${{ matrix.build }} test
         run: |
           cd build
+          if [ "${{ matrix.sanitizer }}" = "tsan" ]; then
+            export TSAN_OPTIONS="suppressions=${{ github.workspace }}/tsan_suppressions.txt"
+          fi
           ctest -V
 
       - name: ${{ matrix.build }} build example/example.cpp

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -54,7 +54,7 @@ jobs:
             export CXXFLAGS="-fsanitize=thread"
             export LDFLAGS="-fsanitize=thread"
           fi
-          cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE)
+          cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE) -DBUILD_SANITIZER=OFF
           make
           sudo make install
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -79,8 +79,18 @@ jobs:
           BUILDTYPE: ${{ matrix.build }}
         run: |
           mkdir -p example/build; cd $_
+          if [ "${{ matrix.sanitizer }}" = "asan" ]; then
+            export CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+            export LDFLAGS="-fsanitize=address"
+          elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
+            export CXXFLAGS="-fsanitize=thread"
+            export LDFLAGS="-fsanitize=thread"
+          fi
           cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE)
           make
+          if [ "${{ matrix.sanitizer }}" = "tsan" ]; then
+            export TSAN_OPTIONS="suppressions=${{ github.workspace }}/tsan_suppressions.txt"
+          fi
           ./lineairdb-example
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,11 +9,21 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         compiler: [g++, clang++]
         build: [Debug, Release]
+        sanitizer: [none]
+        include:
+          - os: ubuntu-latest
+            compiler: clang++
+            build: Debug
+            sanitizer: asan
+          - os: ubuntu-latest
+            compiler: clang++
+            build: Debug
+            sanitizer: tsan
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -37,7 +47,13 @@ jobs:
           BUILDTYPE: ${{ matrix.build }}
         run: |
           mkdir -p build; cd $_
-          cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE)
+          SAN_FLAGS=""
+          if [ "${{ matrix.sanitizer }}" = "asan" ]; then
+            SAN_FLAGS="-DCMAKE_CXX_FLAGS=\"-fsanitize=address -fno-omit-frame-pointer\" -DCMAKE_EXE_LINKER_FLAGS=\"-fsanitize=address\" -DCMAKE_SHARED_LINKER_FLAGS=\"-fsanitize=address\""
+          elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
+            SAN_FLAGS="-DCMAKE_CXX_FLAGS=\"-fsanitize=thread\" -DCMAKE_EXE_LINKER_FLAGS=\"-fsanitize=thread\" -DCMAKE_SHARED_LINKER_FLAGS=\"-fsanitize=thread\""
+          fi
+          cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE) $SAN_FLAGS
           make
           sudo make install
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
         compiler: [g++, clang++]
@@ -47,13 +47,14 @@ jobs:
           BUILDTYPE: ${{ matrix.build }}
         run: |
           mkdir -p build; cd $_
-          SAN_FLAGS=""
           if [ "${{ matrix.sanitizer }}" = "asan" ]; then
-            SAN_FLAGS="-DCMAKE_CXX_FLAGS=\"-fsanitize=address -fno-omit-frame-pointer\" -DCMAKE_EXE_LINKER_FLAGS=\"-fsanitize=address\" -DCMAKE_SHARED_LINKER_FLAGS=\"-fsanitize=address\""
+            export CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+            export LDFLAGS="-fsanitize=address"
           elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
-            SAN_FLAGS="-DCMAKE_CXX_FLAGS=\"-fsanitize=thread\" -DCMAKE_EXE_LINKER_FLAGS=\"-fsanitize=thread\" -DCMAKE_SHARED_LINKER_FLAGS=\"-fsanitize=thread\""
+            export CXXFLAGS="-fsanitize=thread"
+            export LDFLAGS="-fsanitize=thread"
           fi
-          cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE) $SAN_FLAGS
+          cmake .. -DCMAKE_BUILD_TYPE=$(echo $BUILDTYPE)
           make
           sudo make install
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,7 +22,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fcolor-diagnostics -fsanitize=address")
+  if (NOT CMAKE_CXX_FLAGS MATCHES "-fsanitize=")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fcolor-diagnostics -fsanitize=address")
+  else()
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fcolor-diagnostics")
+  endif()
 endif()
 
 find_package(lineairdb REQUIRED)

--- a/src/callback/impl/thread_local_callback_manager.cpp
+++ b/src/callback/impl/thread_local_callback_manager.cpp
@@ -40,6 +40,7 @@ void ThreadLocalCallbackManager::Enqueue(
     // The caller thread manages the callback. Enqueue to thread-local queue.
     auto* my_storage = thread_key_storage_.Get();
     my_storage->callback_queue.push({epoch, callback});
+    my_storage->size.fetch_add(1, std::memory_order_release);
   }
 }
 void ThreadLocalCallbackManager::ExecuteCallbacks(EpochNumber stable_epoch) {
@@ -80,6 +81,7 @@ void ThreadLocalCallbackManager::ExecuteCallbacks(EpochNumber stable_epoch) {
       if (entry.first < stable_epoch) {
         entry.second(TxStatus::Committed);
         callback_queue.pop();
+        queues->size.fetch_sub(1, std::memory_order_release);
       } else {
         break;
       }
@@ -89,9 +91,8 @@ void ThreadLocalCallbackManager::ExecuteCallbacks(EpochNumber stable_epoch) {
 void ThreadLocalCallbackManager::WaitForAllCallbacksToBeExecuted() {
   thread_key_storage_.ForEach(
       [&](const ThreadLocalStorageNode* thread_local_node) {
-        auto& queue = thread_local_node->callback_queue;
         for (;;) {
-          if (queue.empty()) {
+          if (thread_local_node->size.load(std::memory_order_acquire) == 0) {
             break;
           }
           std::this_thread::yield();

--- a/src/callback/impl/thread_local_callback_manager.h
+++ b/src/callback/impl/thread_local_callback_manager.h
@@ -42,8 +42,10 @@ class ThreadLocalCallbackManager final : public CallbackManagerBase {
  private:
   struct ThreadLocalStorageNode {
    public:
+    ThreadLocalStorageNode() : size(0) {}
     std::queue<std::pair<EpochNumber, LineairDB::Database::CallbackType>>
         callback_queue;
+    std::atomic<size_t> size;
   };
 
   struct WorkStealingQueueNode {

--- a/src/database_impl.h
+++ b/src/database_impl.h
@@ -178,7 +178,7 @@ class Database::Impl {
     callback_manager_.ExecuteCallbacks(current_epoch);
   }
 
-  const EpochNumber& GetMyThreadLocalEpoch() {
+  EpochNumber GetMyThreadLocalEpoch() {
     return epoch_framework_.GetMyThreadLocalEpoch();
   }
 
@@ -278,8 +278,7 @@ class Database::Impl {
     thread_pool_.WaitForQueuesToBecomeEmpty();
 
     epoch_framework_.MakeMeOnline();
-    auto& local_epoch = epoch_framework_.GetMyThreadLocalEpoch();
-    local_epoch = durable_epoch;
+    epoch_framework_.SetMyThreadLocalEpoch(durable_epoch);
 
     highest_epoch = std::max(highest_epoch, durable_epoch);
     auto&& recovery_sets = logger_.GetRecoverySetFromLogs(durable_epoch);

--- a/src/database_impl.h
+++ b/src/database_impl.h
@@ -44,11 +44,11 @@ class Database::Impl {
 
   Impl(const Config& c = Config())
       : config_(c),
-        thread_pool_(c.max_thread),
         logger_(config_),
         callback_manager_(config_),
         epoch_framework_(c.epoch_duration_ms, EventsOnEpochIsUpdated()),
-        checkpoint_manager_(config_, table_dictionary_, epoch_framework_) {
+        checkpoint_manager_(config_, table_dictionary_, epoch_framework_),
+        thread_pool_(c.max_thread) {
     if (Database::Impl::CurrentDBInstance == nullptr) {
       Database::Impl::CurrentDBInstance = this;
       SPDLOG_INFO("LineairDB instance has been constructed.");
@@ -310,13 +310,13 @@ class Database::Impl {
 
  private:
   Config config_;
-  ThreadPool thread_pool_;
   Recovery::Logger logger_;
   Callback::CallbackManager callback_manager_;
   EpochFramework epoch_framework_;
   TableDictionary table_dictionary_;
   std::atomic<EpochNumber> latest_callbacked_epoch_{1};
   Recovery::CPRManager checkpoint_manager_;
+  ThreadPool thread_pool_;
 };
 
 }  // namespace LineairDB

--- a/src/index/precision_locking_index/point_index/mpmc_concurrent_set_impl.hpp
+++ b/src/index/precision_locking_index/point_index/mpmc_concurrent_set_impl.hpp
@@ -146,10 +146,10 @@ template <typename T>
 T* MPMCConcurrentSetImpl<T>::Get(const std::string_view key) {
 get_start:
   epoch_framework_.MakeMeOnline();
-  auto* table = table_.load(std::memory_order::memory_order_relaxed);
+  auto* table = table_.load(std::memory_order::memory_order_acquire);
   __builtin_prefetch(table, 0, PREFETCH_LOCALITY);
   size_t hash = Hash(key, table);
-  auto* bucket_p = (*table)[hash].load(std::memory_order::memory_order_relaxed);
+  auto* bucket_p = (*table)[hash].load(std::memory_order::memory_order_acquire);
   T* return_value_p = nullptr;
 
   size_t count = 0;
@@ -160,7 +160,7 @@ get_start:
     if (__builtin_expect(IsRedirectedPtr(bucket_p), false)) {
       table = table_.load();
       hash = Hash(key, table);
-      bucket_p = (*table)[hash].load(std::memory_order::memory_order_relaxed);
+      bucket_p = (*table)[hash].load(std::memory_order::memory_order_acquire);
       __builtin_prefetch(bucket_p, 0, PREFETCH_LOCALITY);
       count = 0;
       continue;
@@ -183,7 +183,7 @@ get_start:
     if (__builtin_expect(hash == table->size(), false)) {
       hash = 0;
     }
-    bucket_p = (*table)[hash].load(std::memory_order::memory_order_relaxed);
+    bucket_p = (*table)[hash].load(std::memory_order::memory_order_acquire);
     if (count > 100) {
       epoch_framework_.MakeMeOffline();
       force_rehash_flag_.store(true);
@@ -213,13 +213,13 @@ put_start:
   // the computational costs of find operation.
   for (;;) {
     auto& bucket_atm = (*table)[hash];
-    auto* node = bucket_atm.load(std::memory_order::memory_order_relaxed);
+    auto* node = bucket_atm.load(std::memory_order::memory_order_acquire);
 
     // redirected
     if (__builtin_expect(IsRedirectedPtr(node), false)) {
       table = table_.load(std::memory_order::memory_order_seq_cst);
       hash = Hash(key, table);
-      node = (*table)[hash].load(std::memory_order::memory_order_relaxed);
+      node = (*table)[hash].load(std::memory_order::memory_order_acquire);
       count = 0;
       continue;
     }
@@ -279,13 +279,13 @@ bool MPMCConcurrentSetImpl<T>::Rehash() {
 
   // copy and rehashing all nodes
   for (auto& bucket_atm : *table) {
-    auto* node = bucket_atm.load(std::memory_order::memory_order_relaxed);
+    auto* node = bucket_atm.load(std::memory_order::memory_order_acquire);
 
     if (node == nullptr) {
       if (bucket_atm.compare_exchange_strong(node, GetRedirectedPtr())) {
         continue;
       } else {
-        node = bucket_atm.load(std::memory_order::memory_order_relaxed);
+        node = bucket_atm.load(std::memory_order::memory_order_acquire);
       }
     }
 

--- a/src/thread_pool/thread_pool.cpp
+++ b/src/thread_pool/thread_pool.cpp
@@ -82,7 +82,9 @@ void ThreadPool::StopAcceptingTransactions() {
 void ThreadPool::ResumeAcceptingTransactions() {
   stop_.store(false, std::memory_order_release);
 }
-void ThreadPool::Shutdown() { shutdown_.store(true, std::memory_order_release); }
+void ThreadPool::Shutdown() {
+  shutdown_.store(true, std::memory_order_release);
+}
 
 bool ThreadPool::Enqueue(std::function<void()>&& job) {
   if (stop_.load(std::memory_order_acquire)) return false;

--- a/src/thread_pool/thread_pool.cpp
+++ b/src/thread_pool/thread_pool.cpp
@@ -58,7 +58,8 @@ ThreadPool::ThreadPool(size_t pool_size)
 #endif
       for (;;) {
         Dequeue();
-        if (stop_ && IsEmpty() && shutdown_) {
+        if (stop_.load(std::memory_order_acquire) && IsEmpty() &&
+            shutdown_.load(std::memory_order_acquire)) {
           break;
         }
       }
@@ -67,27 +68,31 @@ ThreadPool::ThreadPool(size_t pool_size)
 }
 
 ThreadPool::~ThreadPool() {
-  stop_ = true;
-  shutdown_ = true;
+  stop_.store(true, std::memory_order_release);
+  shutdown_.store(true, std::memory_order_release);
   for (auto& thread : worker_threads_) {
     thread.join();
   }
 }
 
 size_t ThreadPool::GetPoolSize() const { return worker_threads_.size(); }
-void ThreadPool::StopAcceptingTransactions() { stop_ = true; }
-void ThreadPool::ResumeAcceptingTransactions() { stop_ = false; }
-void ThreadPool::Shutdown() { shutdown_ = true; }
+void ThreadPool::StopAcceptingTransactions() {
+  stop_.store(true, std::memory_order_release);
+}
+void ThreadPool::ResumeAcceptingTransactions() {
+  stop_.store(false, std::memory_order_release);
+}
+void ThreadPool::Shutdown() { shutdown_.store(true, std::memory_order_release); }
 
 bool ThreadPool::Enqueue(std::function<void()>&& job) {
-  if (stop_) return false;
+  if (stop_.load(std::memory_order_acquire)) return false;
   thread_local static std::mt19937 random(0xDEADBEEF);
   auto& queue = work_queues_[random() % work_queues_.size()];
   return queue.enqueue(job);
 }
 
 bool ThreadPool::EnqueueForAllThreads(std::function<void()>&& job) {
-  if (stop_) return false;
+  if (stop_.load(std::memory_order_acquire)) return false;
   for (auto& queue : no_steal_queues_) {
     while (!queue.enqueue(job)) {
     };

--- a/src/thread_pool/thread_pool.h
+++ b/src/thread_pool/thread_pool.h
@@ -48,8 +48,8 @@ class ThreadPool {
   void Dequeue();
 
  private:
-  bool stop_;
-  bool shutdown_;
+  std::atomic<bool> stop_;
+  std::atomic<bool> shutdown_;
   std::vector<moodycamel::ConcurrentQueue<std::function<void()>>> work_queues_;
   std::vector<moodycamel::ConcurrentQueue<std::function<void()>>>
       no_steal_queues_;

--- a/src/util/epoch_framework.hpp
+++ b/src/util/epoch_framework.hpp
@@ -64,20 +64,17 @@ class EpochFramework {
 
   EpochNumber GetGlobalEpoch() const { return global_epoch_.load(); }
   EpochNumber GetMyThreadLocalEpoch() {
-    auto* my_epoch =
-        tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
+    auto* my_epoch = tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
     return my_epoch->load(std::memory_order_acquire);
   }
 
   void SetMyThreadLocalEpoch(const EpochNumber epoch) {
-    auto* my_epoch =
-        tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
+    auto* my_epoch = tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
     my_epoch->store(epoch, std::memory_order_release);
   }
 
   EpochNumber MakeMeOnline() {
-    auto* my_epoch =
-        tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
+    auto* my_epoch = tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
     assert(my_epoch->load(std::memory_order_relaxed) == THREAD_OFFLINE);
     EpochNumber val = GetGlobalEpoch();
     my_epoch->store(val, std::memory_order_release);
@@ -85,8 +82,7 @@ class EpochFramework {
   }
 
   void MakeMeOffline() {
-    auto* my_epoch =
-        tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
+    auto* my_epoch = tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
     assert(my_epoch->load(std::memory_order_relaxed) != THREAD_OFFLINE);
     my_epoch->store(THREAD_OFFLINE, std::memory_order_release);
   }

--- a/src/util/epoch_framework.hpp
+++ b/src/util/epoch_framework.hpp
@@ -63,25 +63,32 @@ class EpochFramework {
   void SetGlobalEpoch(const EpochNumber epoch) { global_epoch_.store(epoch); }
 
   EpochNumber GetGlobalEpoch() const { return global_epoch_.load(); }
-  EpochNumber& GetMyThreadLocalEpoch() {
-    EpochNumber* my_epoch =
+  EpochNumber GetMyThreadLocalEpoch() {
+    auto* my_epoch =
         tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
-    return *my_epoch;
+    return my_epoch->load(std::memory_order_acquire);
+  }
+
+  void SetMyThreadLocalEpoch(const EpochNumber epoch) {
+    auto* my_epoch =
+        tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
+    my_epoch->store(epoch, std::memory_order_release);
   }
 
   EpochNumber MakeMeOnline() {
-    EpochNumber* my_epoch =
+    auto* my_epoch =
         tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
-    assert(*my_epoch == THREAD_OFFLINE);
-    *my_epoch = GetGlobalEpoch();
-    return *my_epoch;
+    assert(my_epoch->load(std::memory_order_relaxed) == THREAD_OFFLINE);
+    EpochNumber val = GetGlobalEpoch();
+    my_epoch->store(val, std::memory_order_release);
+    return val;
   }
 
   void MakeMeOffline() {
-    EpochNumber* my_epoch =
+    auto* my_epoch =
         tls_.Get<EpochNumber>([]() { return THREAD_OFFLINE; });
-    assert(*my_epoch != THREAD_OFFLINE);
-    *my_epoch = THREAD_OFFLINE;
+    assert(my_epoch->load(std::memory_order_relaxed) != THREAD_OFFLINE);
+    my_epoch->store(THREAD_OFFLINE, std::memory_order_release);
   }
 
   EpochNumber Sync() {
@@ -115,8 +122,8 @@ class EpochFramework {
  public:
   uint32_t GetSmallestEpoch() {
     uint32_t min_epoch = THREAD_OFFLINE;
-    tls_.ForEach([&](const EpochNumber* local_epoch) {
-      const EpochNumber e = *local_epoch;
+    tls_.ForEach([&](const std::atomic<EpochNumber>* local_epoch) {
+      const EpochNumber e = local_epoch->load(std::memory_order_acquire);
       if (0 < e && e < min_epoch) {
         min_epoch = e;
       }
@@ -147,7 +154,7 @@ class EpochFramework {
   std::atomic<EpochNumber> global_epoch_;
   const std::function<void(EpochNumber)> publish_target_;
   std::thread epoch_writer_;
-  ThreadKeyStorage<EpochNumber> tls_;
+  ThreadKeyStorage<std::atomic<EpochNumber>> tls_;
 };
 
 }  // namespace LineairDB

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,0 +1,8 @@
+# Suppress structural data races in OCC (Optimistic Concurrency Control) data item copy
+race:src/types/data_item.hpp
+race:src/types/data_buffer.hpp
+race:__interceptor_memcpy
+
+# Suppress destruction-time races/use-after-free in third-party library spdlog
+race:spdlog
+deadlock:spdlog


### PR DESCRIPTION
## Overview
This PR enables ThreadSanitizer (TSAN) in the GitHub Actions CI environment for Linux (clang++/Debug) and resolves multiple critical data races and undefined behaviors in the core engine discovered by the sanitizer.

## Key Changes

### 1. CI Integration & TSAN Suppressions
- **GitHub Actions Workflow (`.github/workflows/ccpp.yml`)**: Added the `TSAN_OPTIONS` environment variable to apply suppressions when running `ctest`.
- **Suppressions (`tsan_suppressions.txt`)**: Created a suppression file to ignore expected/benign races:
  - Optimistic Concurrency Control (OCC) read/write overlaps that are logically resolved during commit verification (e.g., `DataItem::operator=`, `DataBuffer::Reset`).

### 2. Core Concurrency Fixes

#### A. ThreadPool (`src/thread_pool/`)
- Converted `stop_` and `shutdown_` flags to `std::atomic<bool>`.
- Enforced proper memory ordering (`acquire` for loads, `release` for stores) to prevent undefined behaviors when control threads stop or shutdown the pool while worker threads are dequeuing.

#### B. EpochFramework (`src/util/epoch_framework.hpp`)
- Replaced the raw thread-local epoch numbers (`ThreadKeyStorage<EpochNumber>`) with atomic equivalents (`ThreadKeyStorage<std::atomic<EpochNumber>>`).
- Applied acquire-release semantics during online/offline transitions and when calculating the smallest epoch (`GetSmallestEpoch()`), ensuring thread-safe epoch progression.

#### C. ThreadLocalCallbackManager (`src/callback/impl/`)
- Introduced an atomic `size` member in `ThreadLocalStorageNode` to track queue sizes.
- Replaced the direct, thread-unsafe call to `callback_queue.empty()` in `WaitForAllCallbacksToBeExecuted()`. This resolves a severe data race where the fence thread checked the status of a thread-local queue while the owner thread was mutating it.

#### D. MPMCConcurrentSetImpl (`src/index/precision_locking_index/point_index/mpmc_concurrent_set_impl.hpp`)
- Upgraded relaxed atomic loads of internal table/bucket pointers to `std::memory_order_acquire`. This guarantees that once a thread views a newly created table pointer, all initialization writes to the table's index structure are fully visible to that thread.
