### PR TITLE
fix: prevent epoch advancement deadlock in thread-local WAL logger

### DIFF
--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -37,7 +37,7 @@ std::atomic<size_t> ThreadLocalLogger::ThreadLocalStorageNode::ThreadIdCounter =
     {0};
 
 ThreadLocalLogger::ThreadLocalLogger(const Config& config)
-    : WorkingDir(config.work_dir) {
+    : WorkingDir(config.work_dir), is_alive_(std::make_shared<bool>(true)) {
   LineairDB::Util::SetUpSPDLog();
 }
 
@@ -45,14 +45,18 @@ ThreadLocalLogger::ThreadLocalStorageNode* ThreadLocalLogger::GetMyStorage() {
   auto* my_storage = thread_key_storage_.Get();
   struct ThreadExitNotifier {
     ThreadLocalStorageNode* node;
-    ThreadExitNotifier(ThreadLocalStorageNode* n) : node(n) {}
+    std::weak_ptr<bool> is_alive;
+    ThreadExitNotifier(ThreadLocalStorageNode* n, std::weak_ptr<bool> alive)
+        : node(n), is_alive(alive) {}
     ~ThreadExitNotifier() {
-      if (node) {
-        node->durable_epoch.store(EpochFramework::THREAD_OFFLINE);
+      if (auto lock = is_alive.lock()) {
+        if (node) {
+          node->durable_epoch.store(EpochFramework::THREAD_OFFLINE);
+        }
       }
     }
   };
-  thread_local ThreadExitNotifier notifier(my_storage);
+  thread_local ThreadExitNotifier notifier(my_storage, is_alive_);
   return my_storage;
 }
 

--- a/src/recovery/impl/thread_local_logger.cpp
+++ b/src/recovery/impl/thread_local_logger.cpp
@@ -41,8 +41,23 @@ ThreadLocalLogger::ThreadLocalLogger(const Config& config)
   LineairDB::Util::SetUpSPDLog();
 }
 
-void ThreadLocalLogger::RememberMe(const EpochNumber epoch) {
+ThreadLocalLogger::ThreadLocalStorageNode* ThreadLocalLogger::GetMyStorage() {
   auto* my_storage = thread_key_storage_.Get();
+  struct ThreadExitNotifier {
+    ThreadLocalStorageNode* node;
+    ThreadExitNotifier(ThreadLocalStorageNode* n) : node(n) {}
+    ~ThreadExitNotifier() {
+      if (node) {
+        node->durable_epoch.store(EpochFramework::THREAD_OFFLINE);
+      }
+    }
+  };
+  thread_local ThreadExitNotifier notifier(my_storage);
+  return my_storage;
+}
+
+void ThreadLocalLogger::RememberMe(const EpochNumber epoch) {
+  auto* my_storage = GetMyStorage();
   my_storage->durable_epoch.store(epoch);
 }
 
@@ -65,7 +80,7 @@ void ThreadLocalLogger::Enqueue(const WriteSetType& ws_ref, EpochNumber epoch,
       record.key_value_pairs.emplace_back(std::move(kvp));
     }
   }
-  auto* my_storage = thread_key_storage_.Get();
+  auto* my_storage = GetMyStorage();
   my_storage->log_records.emplace_back(std::move(record));
 
   if (entrusting) {
@@ -83,12 +98,12 @@ void ThreadLocalLogger::Enqueue(const WriteSetType& ws_ref, EpochNumber epoch,
     msgpack::pack(my_storage->log_file, my_storage->log_records);
     my_storage->log_file.flush();
     my_storage->log_records.clear();
-    my_storage->durable_epoch.store(epoch);
+    my_storage->durable_epoch.store(EpochFramework::THREAD_OFFLINE);
   }
 }
 
 void ThreadLocalLogger::FlushLogs(EpochNumber stable_epoch) {
-  auto* my_storage = thread_key_storage_.Get();
+  auto* my_storage = GetMyStorage();
 
   if (!my_storage->log_records.empty()) {
     if (!my_storage->log_file.is_open()) {
@@ -106,7 +121,7 @@ void ThreadLocalLogger::FlushLogs(EpochNumber stable_epoch) {
 
 void ThreadLocalLogger::TruncateLogs(
     const EpochNumber checkpoint_completed_epoch) {
-  auto* my_storage = thread_key_storage_.Get();
+  auto* my_storage = GetMyStorage();
 
   assert(my_storage->truncated_epoch <= checkpoint_completed_epoch);
   if (checkpoint_completed_epoch == my_storage->truncated_epoch) return;

--- a/src/recovery/impl/thread_local_logger.h
+++ b/src/recovery/impl/thread_local_logger.h
@@ -37,6 +37,8 @@ namespace LineairDB {
 namespace Recovery {
 
 class ThreadLocalLogger final : public LoggerBase {
+  struct ThreadLocalStorageNode;
+
  public:
   ThreadLocalLogger(const Config&);
   void RememberMe(const EpochNumber) final override;
@@ -48,6 +50,9 @@ class ThreadLocalLogger final : public LoggerBase {
   EpochNumber GetMinDurableEpochForAllThreads() final override;
   std::string GetLogFileName(size_t thread_id) const;
   std::string GetWorkingLogFileName(size_t thread_id) const;
+
+ private:
+  ThreadLocalStorageNode* GetMyStorage();
 
  private:
   std::string WorkingDir;

--- a/src/recovery/impl/thread_local_logger.h
+++ b/src/recovery/impl/thread_local_logger.h
@@ -78,6 +78,7 @@ class ThreadLocalLogger final : public LoggerBase {
 
  private:
   ThreadKeyStorage<ThreadLocalStorageNode> thread_key_storage_;
+  std::shared_ptr<bool> is_alive_;
 };
 
 }  // namespace Recovery

--- a/tests/durability_test.cpp
+++ b/tests/durability_test.cpp
@@ -461,17 +461,19 @@ TEST_P(DurabilityTest, TwoPhaseLockingDestructorGracefulShutdown) {
 
 TEST_P(DurabilityTest, ShortLivedThreadsDoNotBlockEpochAdvancement) {
   // Spawn a transaction in a short-lived thread which then exits.
+  // We use handler interface directly on t1 to register t1 in thread-local
+  // storage of ThreadLocalLogger.
   std::thread t1([&]() {
-    TestHelper::DoTransactions(db_.get(), {[&](LineairDB::Transaction& tx) {
-                                 tx.Write<int>("key_from_t1", 42);
-                               }});
+    auto& tx = db_->BeginTransaction();
+    tx.Write<int>("key_from_t1", 42);
+    db_->EndTransaction(tx, [](auto) {});
   });
   t1.join();
 
   // Execute a transaction on the main thread.
-  TestHelper::DoTransactions(db_.get(), {[&](LineairDB::Transaction& tx) {
-                               tx.Write<int>("key_from_main", 100);
-                             }});
+  auto& tx = db_->BeginTransaction();
+  tx.Write<int>("key_from_main", 100);
+  db_->EndTransaction(tx, [](auto) {});
 
   // Call Fence. If the exited thread's local storage is not offline,
   // the min durable epoch will be stuck at E_t1, causing Fence() to

--- a/tests/durability_test.cpp
+++ b/tests/durability_test.cpp
@@ -459,6 +459,26 @@ TEST_P(DurabilityTest, TwoPhaseLockingDestructorGracefulShutdown) {
   db_.reset(nullptr);
 }
 
+TEST_P(DurabilityTest, ShortLivedThreadsDoNotBlockEpochAdvancement) {
+  // Spawn a transaction in a short-lived thread which then exits.
+  std::thread t1([&]() {
+    TestHelper::DoTransactions(db_.get(), {[&](LineairDB::Transaction& tx) {
+                                 tx.Write<int>("key_from_t1", 42);
+                               }});
+  });
+  t1.join();
+
+  // Execute a transaction on the main thread.
+  TestHelper::DoTransactions(db_.get(), {[&](LineairDB::Transaction& tx) {
+                               tx.Write<int>("key_from_main", 100);
+                             }});
+
+  // Call Fence. If the exited thread's local storage is not offline,
+  // the min durable epoch will be stuck at E_t1, causing Fence() to
+  // hang/deadlock.
+  db_->Fence();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ConcurrencyControlProtocols, DurabilityTest,
     ::testing::Values(LineairDB::Config::ConcurrencyControl::SiloNWR,


### PR DESCRIPTION
Prevents epoch advancement stagnation/deadlock in the thread-local WAL logger when short-lived client/worker threads exit or stop executing transactions. 

Currently, when a thread exits, its last durable epoch remains in the thread-local storage node. `GetMinDurableEpochForAllThreads()` iterates over all registered storage nodes, meaning the minimum durable epoch of the system gets permanently stuck at the exited thread's last epoch.

This fix registers a thread-destructor helper (`ThreadExitNotifier`) that marks threads as `THREAD_OFFLINE` upon exit, allowing the epoch calculation to correctly ignore them.
