### PR TITLE
fix: resolve underflow and null-dereference in precision locking index

### DIFF
--- a/src/index/precision_locking_index/range_index/precision_locking.cpp
+++ b/src/index/precision_locking_index/range_index/precision_locking.cpp
@@ -33,7 +33,7 @@ PrecisionLockingIndex::PrecisionLockingIndex(LineairDB::EpochFramework& e)
         while (manager_stop_flag_.load() != true) {
           epoch_manager_ref_.Sync();
           const auto global = epoch_manager_ref_.GetGlobalEpoch();
-          const auto stable_epoch = global - 2;
+          const auto stable_epoch = global >= 2 ? global - 2 : 0;
 
           {
             std::lock_guard<decltype(plock_)> p_guard(plock_);
@@ -41,7 +41,7 @@ PrecisionLockingIndex::PrecisionLockingIndex(LineairDB::EpochFramework& e)
             {
               // Clear predicate list
               auto it = predicate_list_.begin();
-              if (it->first <= stable_epoch) {
+              if (it != predicate_list_.end() && it->first <= stable_epoch) {
                 const auto beg = it;
                 while (it != predicate_list_.end() &&
                        it->first <= stable_epoch) {
@@ -53,7 +53,8 @@ PrecisionLockingIndex::PrecisionLockingIndex(LineairDB::EpochFramework& e)
             {
               // Clear insert_or_delete_keys
               auto it = insert_or_delete_key_set_.begin();
-              if (it->first <= stable_epoch) {
+              if (it != insert_or_delete_key_set_.end() &&
+                  it->first <= stable_epoch) {
                 const auto beg = it;
                 while (it != insert_or_delete_key_set_.end() &&
                        it->first <= stable_epoch) {
@@ -64,15 +65,15 @@ PrecisionLockingIndex::PrecisionLockingIndex(LineairDB::EpochFramework& e)
                 // Before deleting the set of insert_or_delete_keys, we update
                 // the index container to apply such outdated (already
                 // committed) insertions and deletions.
-                for (it = beg; it != end; it++) {
-                  for (const auto& event : it->second) {
+                for (auto curr = beg; curr != end; curr++) {
+                  for (const auto& event : curr->second) {
                     container_[event.key].is_deleted = event.is_delete_event;
                   }
                 }
                 insert_or_delete_key_set_.erase(beg, end);
-                last_processed_epoch_.store(stable_epoch,
-                                            std::memory_order_release);
               }
+              last_processed_epoch_.store(stable_epoch,
+                                          std::memory_order_release);
             }
           }
         }
@@ -208,8 +209,9 @@ void PrecisionLockingIndex::WaitForIndexIsLinearizable() {
   // Wait until the manager thread processes all pending insert/delete events
   // and updates the container. This ensures that all index updates are visible.
   const auto target_epoch = epoch_manager_ref_.GetGlobalEpoch();
-  const auto stable_epoch_target =
-      target_epoch - 2;  // It assumes EpochManager#Sync()
+  const auto stable_epoch_target = target_epoch >= 2
+                                       ? target_epoch - 2
+                                       : 0;  // It assumes EpochManager#Sync()
 
   while (last_processed_epoch_.load(std::memory_order_acquire) <
          stable_epoch_target) {

--- a/tests/unit-tests/precision_locking_test.cpp
+++ b/tests/unit-tests/precision_locking_test.cpp
@@ -142,3 +142,45 @@ TEST_F(PrecisionLockingIndexTest, InsertAfterFailedInsertDueToScan) {
         << "Entry should be found in Scan, proving it's properly indexed";
   }
 }
+
+TEST_F(PrecisionLockingIndexTest, ConcurrentInsertMustAbortDuringScan) {
+  db_->CreateTable("users");
+  const std::string test_key = "concurrent_insert_test_key";
+  std::atomic<bool> scan_started(false);
+  std::atomic<bool> insert_completed(false);
+  std::atomic<bool> insert_succeeded(false);
+
+  std::thread scan_thread([&]() {
+    auto& tx = db_->BeginTransaction();
+    tx.Scan<int>(test_key, std::nullopt,
+                 [](std::string_view, int) { return false; });
+    scan_started.store(true);
+
+    while (!insert_completed.load()) {
+      std::this_thread::yield();
+    }
+    db_->EndTransaction(tx, [](auto) {});
+  });
+
+  std::thread insert_thread([&]() {
+    while (!scan_started.load()) {
+      std::this_thread::yield();
+    }
+
+    auto& tx = db_->BeginTransaction();
+    tx.Insert<int>(test_key, 100);
+    db_->EndTransaction(tx, [&](auto status) {
+      if (status == LineairDB::TxStatus::Committed) {
+        insert_succeeded.store(true);
+      }
+      insert_completed.store(true);
+    });
+  });
+
+  insert_thread.join();
+  scan_thread.join();
+
+  EXPECT_FALSE(insert_succeeded.load())
+      << "The insert transaction should have aborted due to the concurrent "
+         "scan predicate";
+}

--- a/tests/unit-tests/precision_locking_test.cpp
+++ b/tests/unit-tests/precision_locking_test.cpp
@@ -143,7 +143,7 @@ TEST_F(PrecisionLockingIndexTest, InsertAfterFailedInsertDueToScan) {
   }
 }
 
-TEST_F(PrecisionLockingIndexTest, ConcurrentInsertMustAbortDuringScan) {
+TEST_F(PrecisionLockingIndexTest, FenceAtStartupDoesNotUnderflow) {
   db_.reset(nullptr);
   LineairDB::Config config;
   config.enable_recovery = false;
@@ -152,8 +152,19 @@ TEST_F(PrecisionLockingIndexTest, ConcurrentInsertMustAbortDuringScan) {
   config.epoch_duration_ms = 10000;  // 10 seconds epoch duration
   auto db = std::make_unique<LineairDB::Database>(config);
 
-  // This will hang indefinitely on main due to the stable_epoch underflow
+  // Verification: Verify that calling Fence() at startup under low epoch
+  // does not underflow and hang.
   db->Fence();
+}
+
+TEST_F(PrecisionLockingIndexTest, ConcurrentInsertMustAbortDuringScan) {
+  db_.reset(nullptr);
+  LineairDB::Config config;
+  config.enable_recovery = false;
+  config.enable_logging = false;
+  config.enable_checkpointing = false;
+  config.epoch_duration_ms = 10000;  // 10 seconds epoch duration
+  auto db = std::make_unique<LineairDB::Database>(config);
 
   db->CreateTable("users");
   const std::string test_key = "concurrent_insert_test_key";

--- a/tests/unit-tests/precision_locking_test.cpp
+++ b/tests/unit-tests/precision_locking_test.cpp
@@ -144,14 +144,26 @@ TEST_F(PrecisionLockingIndexTest, InsertAfterFailedInsertDueToScan) {
 }
 
 TEST_F(PrecisionLockingIndexTest, ConcurrentInsertMustAbortDuringScan) {
-  db_->CreateTable("users");
+  db_.reset(nullptr);
+  LineairDB::Config config;
+  config.enable_recovery = false;
+  config.enable_logging = false;
+  config.enable_checkpointing = false;
+  config.epoch_duration_ms = 10000;  // 10 seconds epoch duration
+  auto db = std::make_unique<LineairDB::Database>(config);
+
+  // This will hang indefinitely on main due to the stable_epoch underflow
+  db->Fence();
+
+  db->CreateTable("users");
   const std::string test_key = "concurrent_insert_test_key";
   std::atomic<bool> scan_started(false);
   std::atomic<bool> insert_completed(false);
   std::atomic<bool> insert_succeeded(false);
 
   std::thread scan_thread([&]() {
-    auto& tx = db_->BeginTransaction();
+    auto& tx = db->BeginTransaction();
+    tx.SetTable("users");
     tx.Scan<int>(test_key, std::nullopt,
                  [](std::string_view, int) { return false; });
     scan_started.store(true);
@@ -159,7 +171,7 @@ TEST_F(PrecisionLockingIndexTest, ConcurrentInsertMustAbortDuringScan) {
     while (!insert_completed.load()) {
       std::this_thread::yield();
     }
-    db_->EndTransaction(tx, [](auto) {});
+    db->EndTransaction(tx, [](auto) {});
   });
 
   std::thread insert_thread([&]() {
@@ -167,9 +179,10 @@ TEST_F(PrecisionLockingIndexTest, ConcurrentInsertMustAbortDuringScan) {
       std::this_thread::yield();
     }
 
-    auto& tx = db_->BeginTransaction();
+    auto& tx = db->BeginTransaction();
+    tx.SetTable("users");
     tx.Insert<int>(test_key, 100);
-    db_->EndTransaction(tx, [&](auto status) {
+    db->EndTransaction(tx, [&](auto status) {
       if (status == LineairDB::TxStatus::Committed) {
         insert_succeeded.store(true);
       }


### PR DESCRIPTION
Fixes a segmentation fault and premature clearing of index predicates in the `PrecisionLockingIndex` manager thread.

When the global epoch is less than 2, subtracting 2 underflows the unsigned `stable_epoch` calculation, making it evaluate to a huge unsigned integer (e.g. `18446744073709551614`).

In addition, the check `it->first <= stable_epoch` was performed without verifying if `it` is a valid iterator (`it != predicate_list_.end()`). This leads to undefined behavior or segmentation fault on empty/newly initialized databases, and clears active predicates prematurely, violating serializability/phantom avoidance.
