### PR TITLE
fix: resolve data item lock corruption in 2PL under CPR checkpointing

### DIFF
--- a/src/recovery/checkpoint_manager.hpp
+++ b/src/recovery/checkpoint_manager.hpp
@@ -116,34 +116,50 @@ class CPRManager {
               record.epoch = checkpoint_epoch_.load() + 1;
 
               dict_ref_.ForEachTable([&](LineairDB::Table& table) {
-                table.GetPrimaryIndex().ForEach(
-                    [&](std::string_view key, LineairDB::DataItem& data_item) {
-                      data_item.ExclusiveLock();
+                table.GetPrimaryIndex().ForEach([&](std::string_view key,
+                                                    LineairDB::DataItem&
+                                                        data_item) {
+                  const bool is_2pl =
+                      config_ref_.concurrency_control_protocol ==
+                      LineairDB::Config::ConcurrencyControl::TwoPhaseLocking;
+                  if (is_2pl) {
+                    data_item.ExclusiveLock2PL();
+                  } else {
+                    data_item.ExclusiveLockSilo();
+                  }
 
-                      // Skip deleted items (not initialized)
-                      if (!data_item.IsInitialized()) {
-                        data_item.ExclusiveUnlock();
-                        return true;
-                      }
+                  // Skip deleted items (not initialized)
+                  if (!data_item.IsInitialized()) {
+                    if (is_2pl) {
+                      data_item.ExclusiveUnlock2PL();
+                    } else {
+                      data_item.ExclusiveUnlockSilo();
+                    }
+                    return true;
+                  }
 
-                      Logger::LogRecord::KeyValuePair kvp;
-                      kvp.table_name = table.GetTableName();
-                      kvp.key = key;
-                      if (data_item.checkpoint_buffer.IsEmpty()) {
-                        // this data item holds version which has written before
-                        // the point of consistency.
-                        kvp.buffer = data_item.buffer.toString();
-                      } else {
-                        kvp.buffer = data_item.checkpoint_buffer.toString();
-                        data_item.checkpoint_buffer.Reset(nullptr, 0);
-                      }
-                      kvp.tid.epoch = record.epoch;
-                      kvp.tid.tid = 0;
-                      record.key_value_pairs.emplace_back(std::move(kvp));
+                  Logger::LogRecord::KeyValuePair kvp;
+                  kvp.table_name = table.GetTableName();
+                  kvp.key = key;
+                  if (data_item.checkpoint_buffer.IsEmpty()) {
+                    // this data item holds version which has written before
+                    // the point of consistency.
+                    kvp.buffer = data_item.buffer.toString();
+                  } else {
+                    kvp.buffer = data_item.checkpoint_buffer.toString();
+                    data_item.checkpoint_buffer.Reset(nullptr, 0);
+                  }
+                  kvp.tid.epoch = record.epoch;
+                  kvp.tid.tid = 0;
+                  record.key_value_pairs.emplace_back(std::move(kvp));
 
-                      data_item.ExclusiveUnlock();
-                      return true;
-                    });
+                  if (is_2pl) {
+                    data_item.ExclusiveUnlock2PL();
+                  } else {
+                    data_item.ExclusiveUnlockSilo();
+                  }
+                  return true;
+                });
               });
               records.emplace_back(std::move(record));
 

--- a/src/types/data_item.hpp
+++ b/src/types/data_item.hpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <cstring>
 #include <msgpack.hpp>
+#include <thread>
 #include <type_traits>
 
 #include "concurrency_control/pivot_object.hpp"
@@ -79,39 +80,35 @@ struct DataItem {
     checkpoint_buffer.Reset(buffer);
   }
 
-  void ExclusiveLock() {
-    // Acquire exclusive locking for all protocols:
-
-    {
-      // for Silo, Silo+NWR. they uses transaction_id as the lock
-      for (;;) {
-        auto tid = transaction_id.load();
-        if (tid.tid & 1llu) {
-          std::this_thread::yield();
-          continue;
-        }
-        auto new_tid = tid;
-        new_tid.tid += 1llu;
-        if (transaction_id.compare_exchange_weak(tid, new_tid)) break;
+  void ExclusiveLockSilo() {
+    for (;;) {
+      auto current = transaction_id.load();
+      if (current.tid & 1u) {
+        std::this_thread::yield();
+        continue;
+      }
+      auto desired = current;
+      desired.tid |= 1u;
+      if (transaction_id.compare_exchange_weak(current, desired)) {
+        break;
       }
     }
-
-    // for TwoPhaseLocking. it uses rw_lock.
-    { GetRWLockRef().Lock(); }
   }
 
-  void ExclusiveUnlock() {
-    // Release exclusive locking for all protocols:
-
-    // for Silo, Silo+NWR. they uses transaction_id as the lock
-    {
-      auto tid = transaction_id.load();
-      tid.tid -= 1llu;
-      transaction_id.store(tid);
+  void ExclusiveUnlockSilo() {
+    for (;;) {
+      auto current = transaction_id.load();
+      auto desired = current;
+      desired.tid &= ~1u;
+      if (transaction_id.compare_exchange_weak(current, desired)) {
+        break;
+      }
     }
-    // for TwoPhaseLocking. it uses rw_lock.
-    { GetRWLockRef().UnLock(); }
   }
+
+  void ExclusiveLock2PL() { GetRWLockRef().Lock(); }
+
+  void ExclusiveUnlock2PL() { GetRWLockRef().UnLock(); }
 
   decltype(readers_writers_lock)& GetRWLockRef() {
     return readers_writers_lock;

--- a/tests/durability_test.cpp
+++ b/tests/durability_test.cpp
@@ -442,20 +442,29 @@ TEST_P(DurabilityTest, TwoPhaseLockingDestructorGracefulShutdown) {
   LineairDB::Config config = db_->GetConfig();
   config.concurrency_control_protocol =
       LineairDB::Config::ConcurrencyControl::TwoPhaseLocking;
+  config.enable_checkpointing = true;
   config.checkpoint_period = 1;  // 1sec
   db_.reset(nullptr);
+  std::filesystem::remove_all(config.work_dir);
   db_ = std::make_unique<LineairDB::Database>(config);
 
-  // Execute multiple write transactions to the same key to increment the TID.
-  // This triggers the odd TID bug under 2PL which previously caused deadlocks.
-  for (int i = 0; i < 5; ++i) {
-    TestHelper::DoTransactions(db_.get(), {[&](LineairDB::Transaction& tx) {
-                                 tx.Write<int>("key", i);
-                               }});
-  }
+  // Execute continuous write transactions to the same key from a background
+  // thread to ensure concurrent checkpointing conflicts with 2PL lock updates.
+  std::atomic<bool> stop(false);
+  std::thread writer([&]() {
+    int i = 0;
+    while (!stop.load()) {
+      auto& tx = db_->BeginTransaction();
+      tx.Write<int>("key", i++);
+      db_->EndTransaction(tx, [](auto) {});
+    }
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  stop.store(true);
+  writer.join();
 
   // Destruct the database. If there's a deadlock/hang, the test will hang here.
-  // If the bug is fixed, it will complete immediately.
   db_.reset(nullptr);
 }
 


### PR DESCRIPTION
### Summary
This PR resolves database hangs/deadlocks during destructor cleanup when using **Two-Phase Locking (2PL)** with **CPR checkpointing** enabled. 
                                                                                                                                                                             
Under 2PL, transaction execution updates the `transaction_id` of data items directly upon commit. Previously, CPR checkpointing unconditionally locked the Silo lock bit (`transaction_id.tid & 1`) in addition to the 2PL `rw_lock`. This corrupted the transaction ID states and caused concurrent write conflicts.
                                                                                                                                                                             
To solve this, we split the locking functions into protocol-specific implementations and branch on the active Concurrency Control (CC) protocol inside the Checkpoint Manager. Under 2PL, CPR checkpointing now only locks/unlocks using the `rw_lock`, leaving the `transaction_id` untouched.